### PR TITLE
Allow OutputAdapters to be from any namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 
 *.log
 *.gem
+
+/TAGS

--- a/lib/sublayer/components/output_adapters.rb
+++ b/lib/sublayer/components/output_adapters.rb
@@ -4,7 +4,21 @@ module Sublayer
       attr_reader :name
 
       def self.create(options)
-        ("Sublayer::Components::OutputAdapters::"+options[:type].to_s.camelize).constantize.new(options)
+        klass = if options.has_key?(:class)
+          klass = options[:class]
+          if klass.is_a?(String)
+            klass.constantize
+          elsif klass.is_a?(Class)
+            klass
+          else
+            raise "Invalid :class option"
+          end
+        elsif (type = options[:type])
+          "Sublayer::Components::OutputAdapters::#{type.to_s.camelize}".constantize
+        else
+          raise "Output adapter must be specified with :class or :type"
+        end
+        klass.new(options)
       end
     end
   end

--- a/spec/components/output_adapter_spec.rb
+++ b/spec/components/output_adapter_spec.rb
@@ -41,4 +41,24 @@ RSpec.describe Sublayer::Components::OutputAdapters do
       end
     end
   end
+
+  context "class:" do
+    it "class: 'String'" do
+      output_adapter = Sublayer::Components::OutputAdapters.create(
+        class: "Sublayer::Components::OutputAdapters::SingleString",
+        name: "modified_file_contents",
+        description: "The modified file contents"
+      )
+      expect(output_adapter).to be_a(Sublayer::Components::OutputAdapters::SingleString)
+    end
+
+    it "class: Constant" do
+      output_adapter = Sublayer::Components::OutputAdapters.create(
+        class: Sublayer::Components::OutputAdapters::SingleString,
+        name: "modified_file_contents",
+        description: "The modified file contents"
+      )
+      expect(output_adapter).to be_a(Sublayer::Components::OutputAdapters::SingleString)
+    end
+  end
 end


### PR DESCRIPTION
Currently we only support `llm_output_adapter type: :single_string` to map `type: :single_string` to `Sublayer::Components::OutputAdapters::SingleString` class within `Sublayer::Components::OutputAdapters` namespace.

This PR adds `class:` key to provide a string or class:

* `llm_output_adapter class: "MyThing::MyAdapter"`
* `llm_output_adapter class: MyThing::MyAdapter`

This is my first PR and was an idea I had from reading the code and trying to understand the gist of generators + output adapters (aka functions/tools).
