### PR TITLE
Scaffold for testing Provider API calls with VCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 
 *.log
 *.gem
+
+/TAGS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sublayer (0.0.5)
+    sublayer (0.0.6)
       activesupport
       colorize
       httparty
@@ -22,6 +22,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     base64 (0.1.1)
     bigdecimal (3.1.4)
     clag (0.0.7)
@@ -42,6 +44,9 @@ GEM
     colorize (1.1.0)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     diff-lcs (1.5.0)
     drb (2.1.1)
       ruby2_keywords
@@ -53,6 +58,7 @@ GEM
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
+    hashdiff (1.1.0)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -71,7 +77,9 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (5.0.5)
     racc (1.7.3)
+    rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -92,6 +100,11 @@ GEM
     ruby2_keywords (0.0.5)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    vcr (6.2.0)
+    webmock (3.23.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     zeitwerk (2.6.13)
 
 PLATFORMS
@@ -104,6 +117,8 @@ DEPENDENCIES
   pry (~> 0.14)
   rspec (~> 3.12)
   sublayer!
+  vcr (~> 6.0)
+  webmock (~> 3.0)
 
 BUNDLED WITH
    2.4.17

--- a/lib/sublayer/providers/claude.rb
+++ b/lib/sublayer/providers/claude.rb
@@ -30,7 +30,7 @@ module Sublayer
         response = HTTParty.post(
           "https://api.anthropic.com/v1/messages",
           headers: {
-            "x-api-key": ENV["ANTHROPIC_API_KEY"],
+            "x-api-key": ENV.fetch("ANTHROPIC_API_KEY"),
             "anthropic-version": "2023-06-01",
             "content-type": "application/json"
           },

--- a/lib/sublayer/providers/open_ai.rb
+++ b/lib/sublayer/providers/open_ai.rb
@@ -5,7 +5,7 @@ module Sublayer
   module Providers
     class OpenAI
       def self.call(prompt:, output_adapter:)
-        client = ::OpenAI::Client.new(access_token: ENV["OPENAI_API_KEY"])
+        client = ::OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY"))
 
         response = client.chat(
           parameters: {

--- a/spec/providers/claude_spec.rb
+++ b/spec/providers/claude_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe Sublayer::Providers::Claude do
+  before do
+    Sublayer.configuration.ai_provider = described_class
+    Sublayer.configuration.ai_model = "claude-3-haiku-20240307"
+  end
+
+  describe "#call" do
+    it "calls the Claude API" do
+      VCR.use_cassette("claude/42") do
+        output_adapter = Sublayer::Components::OutputAdapters.create(
+          type: :single_string,
+          name: "claude_response",
+          description: "The response from Claude"
+        )
+        response = described_class.call(
+          prompt: "What is the meaning of life? Give it to me as a number.",
+          output_adapter: output_adapter
+        )
+
+        expect(response).to eq("42")
+      end
+    end
+  end
+end

--- a/spec/providers/open_ai_spec.rb
+++ b/spec/providers/open_ai_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe Sublayer::Providers::OpenAI do
+  before do
+    Sublayer.configuration.ai_provider = described_class
+    Sublayer.configuration.ai_model = "gpt-3.5-turbo"
+  end
+
+  describe "#call" do
+    it "calls the OpenAI API" do
+      VCR.use_cassette("openai/42") do
+        output_adapter = Sublayer::Components::OutputAdapters.create(
+          type: :single_string,
+          name: "openai_response",
+          description: "The response from OpenAI"
+        )
+        response = described_class.call(
+          prompt: "What is the meaning of life? Give it to me as a number. Just a number. You can do it.",
+          output_adapter: output_adapter
+        )
+
+        expect(response).to eq("42")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,15 @@
 
 require "sublayer"
 
+require "vcr"
+
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/vcr_cassettes"
+  config.hook_into :webmock
+  config.filter_sensitive_data("<OPENAI_API_KEY>") { ENV.fetch("OPENAI_API_KEY") }
+  config.filter_sensitive_data("<ANTHROPIC_API_KEY>") { ENV.fetch("ANTHROPIC_API_KEY") }
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/vcr_cassettes/claude/42.yml
+++ b/spec/vcr_cassettes/claude/42.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"model":"claude-3-haiku-20240307","max_tokens":4096,"system":"        In
+        this environment you have access to a set of tools you can use to answer the
+        user''s question.\n\n        You may call them like this:\n        <function_calls>\n        <invoke>\n          <tool_name>$TOOL_NAME</tool_name>\n          <parameters>\n          <$PARAMETER_NAME>$PARAMETER_VALUE</$PARAMETER_NAME>\n          ...\n          </parameters>\n        </invoke>\n        </function_calls>\n\n        Here
+        are the tools available:\n        <tools>\n                    <tool_description>\n              <tool_name>claude_response</tool_name>\n              <tool_description>The
+        response from Claude</tool_description>\n              <parameters>\n                <name>claude_response</name>\n                <type>string</type>\n                <description>The
+        response from Claude</description>\n              </parameters>\n            </tool_description>\n\n        </tools>\n\n        Respond
+        only with valid xml. The entire response should be wrapped in a <response>
+        tag. Any additional information not inside a tool call should go in a <scratch>
+        tag.\n","messages":[{"role":"user","content":"What is the meaning of life?
+        Give it to me as a number."}]}'
+    headers:
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Apr 2024 05:02:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Requests-Limit:
+      - '5'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '4'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2024-04-17T05:03:17Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '25000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '25000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2024-04-17T05:03:17Z'
+      Request-Id:
+      - req_015QsHRD3V45W8AA5Y6E87PW
+      X-Cloud-Trace-Context:
+      - b64d087d72fbe6cfb063a5ff67dd5625
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8759dcb8ba8f781e-BNE
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"msg_01KRGke9i4BLoBqub59PcScZ","type":"message","role":"assistant","model":"claude-3-haiku-20240307","stop_sequence":null,"usage":{"input_tokens":272,"output_tokens":122},"content":[{"type":"text","text":"Here
+        is my attempt at answering your question:\n<response>\n<scratch>\nThe meaning
+        of life is a deep philosophical question that has been debated for centuries.
+        There is no single, universally agreed-upon answer. However, based on my analysis,
+        I would summarize the meaning of life as:\n</scratch>\n<invoke>\n  <tool_name>claude_response</tool_name>\n  <parameters>\n    <claude_response>42</claude_response>\n  </parameters>\n</invoke>\n</response>"}],"stop_reason":"end_turn"}'
+  recorded_at: Wed, 17 Apr 2024 05:02:20 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/openai/42.yml
+++ b/spec/vcr_cassettes/openai/42.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"What
+        is the meaning of life? Give it to me as a number. Just a number. You can
+        do it."}],"function_call":{"name":"openai_response"},"functions":[{"name":"openai_response","description":"The
+        response from OpenAI","parameters":{"type":"object","properties":{"openai_response":{"type":"string","description":"The
+        response from OpenAI"}}}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Apr 2024 05:02:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, must-revalidate
+      Openai-Model:
+      - gpt-3.5-turbo-0125
+      Openai-Organization:
+      - user-ujpyqwcjd0dls5k3amdh1vei
+      Openai-Processing-Ms:
+      - '318'
+      Openai-Version:
+      - '2020-10-01'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Ratelimit-Limit-Requests:
+      - '5000'
+      X-Ratelimit-Limit-Tokens:
+      - '160000'
+      X-Ratelimit-Remaining-Requests:
+      - '4999'
+      X-Ratelimit-Remaining-Tokens:
+      - '159961'
+      X-Ratelimit-Reset-Requests:
+      - 12ms
+      X-Ratelimit-Reset-Tokens:
+      - 14ms
+      X-Request-Id:
+      - req_30761c9e246d78a84c8e2e3196fe360a
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=8lPtRSJyaUG66kfxZaSYQFOJXwM8PmBgr8VLQCpkYqI-1713330141-1.0.1.1-ZVeD_rRGAEHyDbJlKLPQIN20mA.7VOnvUlngvmGqZ9Fsj0ON3tpokUDBtNUyrdKZzzD7xjkqSkAMoLT5vNcrZQ;
+        path=/; expires=Wed, 17-Apr-24 05:32:21 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=DGN4u5gc_JtpSMUJzy7a3ak1napGOzHzabnHjHACTyM-1713330141686-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8759dcc5fbfca826-SYD
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-9Erj3CjI3Zll4trmTUx3Zm7jkrp0p",
+          "object": "chat.completion",
+          "created": 1713330141,
+          "model": "gpt-3.5-turbo-0125",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": null,
+                "function_call": {
+                  "name": "openai_response",
+                  "arguments": "{\"openai_response\":\"42\"}"
+                }
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 89,
+            "completion_tokens": 7,
+            "total_tokens": 96
+          },
+          "system_fingerprint": "fp_c2295e73ad"
+        }
+  recorded_at: Wed, 17 Apr 2024 05:02:21 GMT
+recorded_with: VCR 6.2.0

--- a/sublayer.gemspec
+++ b/sublayer.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "httparty"
 
   spec.add_development_dependency "rspec", "~> 3.12"
-  spec.add_development_dependency "pry", " ~> 0.14"
+  spec.add_development_dependency "pry", "~> 0.14"
+  spec.add_development_dependency "vcr", "~> 6.0"
+  spec.add_development_dependency "webmock", "~> 3.0"
   spec.add_development_dependency "clag"
 end


### PR DESCRIPTION
See `spec_helper.rb` for configuring env vars to be sanitized from vcr cassette yaml files, to prevent leaking secrets.

```
VCR.configure do |config|
  config.cassette_library_dir = "spec/vcr_cassettes"
  config.hook_into :webmock
  config.filter_sensitive_data("<OPENAI_API_KEY>") { ENV["OPENAI_API_KEY"] }
  config.filter_sensitive_data("<ANTHROPIC_API_KEY>") { ENV["ANTHROPIC_API_KEY"] }
end
```

Also, Github Actions will need to add these env vars (even if they are dummy values since they are stubbed out by VCR with the above code)