### PR TITLE
Extract file-based triggers into its own class, and allow the creation of other types of trigger classes

### DIFF
--- a/lib/sublayer/agents/base.rb
+++ b/lib/sublayer/agents/base.rb
@@ -2,47 +2,51 @@ module Sublayer
   module Agents
     class Base
       class << self
-        attr_accessor :goal_condition_block, :trigger_condition_block, :trigger_on_files_changed_block, :check_status_block, :step_block
+        attr_reader :triggers, :goal_condition_block, :check_status_block, :step_block, :listeners
 
-        def trigger_condition(&block)
-          self.trigger_condition_block = block
+        def trigger(trigger_instance = nil)
+          @triggers ||= []
+
+          if trigger_instance
+            @triggers << trigger_instance
+          else
+            raise ArgumentError, "Either a trigger instance or a block must be provided"
+          end
         end
 
         def trigger_on_files_changed(&block)
-          self.trigger_on_files_changed_block = block
+          trigger(Triggers::FileChange.new(&block))
         end
 
         def goal_condition(&block)
-          self.goal_condition_block = block
+          @goal_condition_block = block
         end
 
         def check_status(&block)
-          self.check_status_block = block
+          @check_status_block = block
         end
 
         def step(&block)
-          self.step_block = block
+          @step_block = block
         end
       end
 
       def run
-        files_to_listen_to = instance_eval(&self.class.trigger_on_files_changed_block).map { |file| File.expand_path(file) }
-        folders = files_to_listen_to.map { |file| File.dirname(file) }.uniq
-
-        listener = Listen.to(*folders) do |modified, added, removed|
-          if files_to_listen_to.any? { |file| modified.include?(file) }
-            take_step
-          end
-        end
-
-        listener.start
-
+        setup_triggers
         take_step
-
         sleep
       end
 
       private
+
+      def setup_triggers
+        @listeners = []
+
+        self.class.triggers.each do |trigger|
+          listener = trigger.setup(self)
+          @listeners << listener if listener
+        end
+      end
 
       def take_step
         instance_eval(&self.class.check_status_block)

--- a/lib/sublayer/triggers/base.rb
+++ b/lib/sublayer/triggers/base.rb
@@ -1,0 +1,13 @@
+module Sublayer
+  module Triggers
+    class Base
+      def setup(agent)
+        raise NotImplementedError, "Subclasses must implement setup method"
+      end
+
+      def activate(agent)
+        agent.send(:take_step)
+      end
+    end
+  end
+end

--- a/lib/sublayer/triggers/file_change.rb
+++ b/lib/sublayer/triggers/file_change.rb
@@ -1,0 +1,20 @@
+module Sublayer
+  module Triggers
+    class FileChange < Base
+      def initialize(&block)
+        @block = block
+      end
+
+      def setup(agent)
+        files_to_watch = agent.instance_eval(&@block)
+        folders = files_to_watch.map { |file| File.dirname(File.expand_path(file)) }.uniq
+
+        Listen.to(*folders) do |modified, added, removed|
+          if files_to_watch.any? { |file| modified.include?(File.expand_path(file)) }
+            activate(agent)
+          end
+        end.start
+      end
+    end
+  end
+end

--- a/spec/agents/base_spec.rb
+++ b/spec/agents/base_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+
+RSpec.describe Sublayer::Agents::Base do
+  let(:test_agent_class) do
+    Class.new(described_class) do
+      trigger_on_files_changed { ["test_file.txt"] }
+      goal_condition { @goal_reached }
+      check_status { @status_checked = true }
+      step { @step_taken = true }
+
+      attr_accessor :goal_reached, :status_checked, :step_taken
+    end
+  end
+
+  let(:agent) { test_agent_class.new }
+
+  describe ".trigger" do
+    it "adds triggers to the agent class" do
+      expect(test_agent_class.triggers.size).to eq(1)
+    end
+
+    it "accepts custom trigger instances" do
+      custom_trigger = Sublayer::Triggers::Base.new
+
+      test_agent_class.trigger(custom_trigger)
+      expect(test_agent_class.triggers.last).to eq(custom_trigger)
+    end
+  end
+
+  describe "#run" do
+    before do
+      allow(Listen).to receive(:to).and_return(double(start: true))
+      allow(agent).to receive(:sleep)
+    end
+
+    it "sets up triggers and takes a step" do
+      expect(agent).to receive(:setup_triggers)
+      expect(agent).to receive(:take_step)
+      expect(agent).to receive(:sleep)
+
+      agent.run
+    end
+  end
+
+  describe "#take_step" do
+    context "when goal is not reached" do
+      before { agent.goal_reached = false }
+
+      it "checks status and takes a step" do
+        agent.send(:take_step)
+        expect(agent.status_checked).to be true
+        expect(agent.step_taken).to be true
+      end
+    end
+
+    context "when the goal is reached" do
+      before { agent.goal_reached = true }
+
+      it "checks status but does not take a step" do
+        agent.send(:take_step)
+        expect(agent.status_checked).to be true
+        expect(agent.step_taken).to be_nil
+      end
+    end
+  end
+end

--- a/spec/agents/examples/rspec_agent.rb
+++ b/spec/agents/examples/rspec_agent.rb
@@ -1,0 +1,33 @@
+class RSpecAgent < Sublayer::Agents::Base
+  def initialize(implementation_file_path:, test_file_path:)
+    @implementation_file_path = implementation_file_path
+    @test_file_path = test_file_path
+    @tests_passing = false
+  end
+
+  trigger_on_files_changed { [@implementation_file_path, @test_file_path] }
+
+  goal_condition { @tests_passing == true }
+
+  check_status do
+    stdout, stderr, status = Sublayer::Actions::RunTestCommandAction.new(
+      test_command: "rspec #{@test_file_path}"
+    ).call
+
+    @test_output = stdout
+    @tests_passing = (status.exitstatus == 0)
+  end
+
+  step do
+    modified_implementation = Sublayer::Generators::ModifiedImplementationToPassTestsGenerator.new(
+      implementation_file_contents: File.read(@implementation_file_path),
+      test_file_contents: File.read(@test_file_path),
+      test_output: @test_output
+    ).generate
+
+    Sublayer::Actions::WriteFileAction.new(
+      file_contents: modified_implementation,
+      file_path: @implementation_file_path
+    ).call
+  end
+end

--- a/spec/agents/rspec_agent_spec.rb
+++ b/spec/agents/rspec_agent_spec.rb
@@ -1,0 +1,79 @@
+require "spec_helper"
+
+require "agents/examples/rspec_agent"
+
+RSpec.describe RSpecAgent do
+  let!(:run_command_action) { class_double("Sublayer::Actions::RunTestCommandAction").as_stubbed_const }
+  let!(:modified_implementation_generator) { class_double("Sublayer::Generators::ModifiedImplementationToPassTestsGenerator").as_stubbed_const }
+  let!(:write_file_action) { class_double("Sublayer::Actions::WriteFileAction").as_stubbed_const }
+  let(:agent) { described_class.new(implementation_file_path: "lib/my_class.rb", test_file_path: "spec/my_class_spec.rb") }
+
+  describe "initialize" do
+    before do
+      allow(run_command_action).to receive(:new).and_return(double(call: ["", "", double(exitstatus: 0)]))
+      allow(modified_implementation_generator).to receive(:new).and_return(double(generate: ""))
+      allow(write_file_action).to receive(:new).and_return(double(call: nil))
+    end
+
+    it "sets the implementation file path" do
+      expect(agent.instance_variable_get(:@implementation_file_path)).to eq("lib/my_class.rb")
+    end
+
+    it "sets the test file path" do
+      expect(agent.instance_variable_get(:@test_file_path)).to eq("spec/my_class_spec.rb")
+    end
+
+    it "sets tests passing to false" do
+      expect(agent.instance_variable_get(:@tests_passing)).to be false
+    end
+  end
+
+  describe "trigger_on_files_changed" do
+    it "correctly sets up the triggers" do
+      expect(Listen).to receive(:to).with(File.dirname(File.expand_path("lib/my_class.rb")), File.dirname(File.expand_path("spec/my_class_spec.rb"))).and_return(double(start: true))
+
+      allow(run_command_action).to receive(:new).and_return(double(call: ["", "", double(exitstatus: 0)]))
+      allow(modified_implementation_generator).to receive(:new).and_return(double(generate: ""))
+      allow(write_file_action).to receive(:new).and_return(double(call: nil))
+      expect(agent.class.triggers.size).to eq(1)
+      allow(agent).to receive(:sleep)
+
+      agent.run
+    end
+  end
+
+  describe "checking status" do
+    context "when the tests are passing" do
+      it "makes it so the goal condition is met" do
+        expect(Listen).to receive(:to).with(File.dirname(File.expand_path("lib/my_class.rb")), File.dirname(File.expand_path("spec/my_class_spec.rb"))).and_return(double(start: true))
+
+        allow(run_command_action).to receive(:new).and_return(double(call: ["", "", double(exitstatus: 0)]))
+        allow(modified_implementation_generator).to receive(:new).and_return(double(generate: ""))
+        allow(write_file_action).to receive(:new).and_return(double(call: nil))
+        allow(agent).to receive(:sleep)
+
+        agent.run
+
+        expect(agent.instance_eval(&agent.class.goal_condition_block)).to be true
+      end
+
+    end
+
+    context "when the tests aren't passing" do
+      it "makes it so the goal condition isn't met" do
+        expect(Listen).to receive(:to).with(File.dirname(File.expand_path("lib/my_class.rb")), File.dirname(File.expand_path("spec/my_class_spec.rb"))).and_return(double(start: true))
+        expect(File).to receive(:read).with("lib/my_class.rb").and_return("class MyClass\nend")
+        expect(File).to receive(:read).with("spec/my_class_spec.rb").and_return("require 'my_class'\n\ndescribe MyClass do\n  it 'does something' do\n    expect(MyClass.new).to be_truthy\n  end\nend")
+
+        allow(run_command_action).to receive(:new).and_return(double(call: ["", "", double(exitstatus: 1)]))
+        allow(modified_implementation_generator).to receive(:new).and_return(double(generate: ""))
+        allow(write_file_action).to receive(:new).and_return(double(call: nil))
+        allow(agent).to receive(:sleep)
+
+        agent.run
+
+        expect(agent.instance_eval(&agent.class.goal_condition_block)).to be false
+      end
+    end
+  end
+end

--- a/spec/triggers/base_spec.rb
+++ b/spec/triggers/base_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe Sublayer::Triggers::Base do
+  let(:test_trigger) { described_class.new }
+  let(:test_agent) { double("Agent") }
+
+  describe "#setup" do
+    it "raises NotImplementedError" do
+      expect { test_trigger.setup(test_agent) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#activate" do
+    it "calls take_step on the agent" do
+      expect(test_agent).to receive(:take_step)
+      test_trigger.activate(test_agent)
+    end
+  end
+end

--- a/spec/triggers/file_change_spec.rb
+++ b/spec/triggers/file_change_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe Sublayer::Triggers::FileChange do
+  let(:test_agent) { double("Agent") }
+  let(:block) { -> { ["file1.txt", "file2.txt"] } }
+  let(:trigger) { described_class.new(&block) }
+
+  describe "#initialize" do
+    it "stores the provided block" do
+      expect(trigger.instance_variable_get(:@block)).to eq(block)
+    end
+  end
+
+  describe "#setup" do
+    let(:listen_mock) { double("Listen") }
+    let(:listener_mock) { double("Listener") }
+
+    before do
+      allow(Listen).to receive(:to).and_return(listen_mock)
+      allow(listen_mock).to receive(:start).and_return(listener_mock)
+      allow(test_agent).to receive(:instance_eval).and_return(["file1.txt", "file2.txt"])
+      allow(File).to receive(:dirname).and_return("/test/path")
+      allow(File).to receive(:expand_path) { |file| "/test/path/#{file}" }
+    end
+
+    it "sets up a listener for the specified files" do
+      expect(Listen).to receive(:to).with("/test/path").and_return(listen_mock)
+      expect(listen_mock).to receive(:start)
+
+      trigger.setup(test_agent)
+    end
+  end
+end


### PR DESCRIPTION
Lay the foundation for the creation of multiple different types of Triggers. Extracted the `trigger_on_files_changed` type trigger into its own FileChange trigger. We'll follow up with new types of core triggers, while still preserving the ability for users to implement their own triggers on a project by project basis similar to output adapters.

With this change merged, I think we're ready to release the new 0.1 version of the gem, and expanding on the functionality of new types of output adapters, creating new types of triggers for agents, and providing many more examples of how to use the agent DSL to build all different types of micro-agents (micro-automations?)