### PR TITLE
Allow users to use strings or symbols in output adapter names

### DIFF
--- a/lib/sublayer/components/output_adapters.rb
+++ b/lib/sublayer/components/output_adapters.rb
@@ -18,6 +18,9 @@ module Sublayer
         else
           raise "Output adapter must be specified with :class or :type"
         end
+
+        options[:name] = options[:name].to_s if options[:name].is_a?(Symbol)
+
         klass.new(options)
       end
     end

--- a/spec/components/output_adapter_spec.rb
+++ b/spec/components/output_adapter_spec.rb
@@ -1,23 +1,121 @@
 require "spec_helper"
 
 RSpec.describe Sublayer::Components::OutputAdapters do
-  context "class:" do
-    it "class: 'String'" do
-      output_adapter = Sublayer::Components::OutputAdapters.create(
-        class: "Sublayer::Components::OutputAdapters::SingleString",
-        name: "modified_file_contents",
-        description: "The modified file contents"
-      )
-      expect(output_adapter).to be_a(Sublayer::Components::OutputAdapters::SingleString)
+  describe ".create" do
+    context "with a built in adapter" do
+      context "when given a string for a name" do
+        it "creates the adapter successfully" do
+          adapter = described_class.create(
+            type: :single_string,
+            name: "test_adapter",
+            description: "a test adapter"
+          )
+
+          expect(adapter).to be_a(Sublayer::Components::OutputAdapters::SingleString)
+          expect(adapter.name).to eq("test_adapter")
+        end
+      end
+
+      context "when given a symbol for a name" do
+        it "creates the adapter successfully" do
+          adapter = described_class.create(
+            type: :single_string,
+            name: :test_adapter,
+            description: "a test adapter"
+          )
+
+          expect(adapter).to be_a(Sublayer::Components::OutputAdapters::SingleString)
+          expect(adapter.name).to eq("test_adapter")
+        end
+      end
     end
 
-    it "class: Constant" do
-      output_adapter = Sublayer::Components::OutputAdapters.create(
-        class: Sublayer::Components::OutputAdapters::SingleString,
-        name: "modified_file_contents",
-        description: "The modified file contents"
-      )
-      expect(output_adapter).to be_a(Sublayer::Components::OutputAdapters::SingleString)
+    context "with a custom adapter class" do
+      class CustomAdapter
+        attr_reader :name, :description
+
+        def initialize(options)
+          @name = options[:name]
+          @description = options[:description]
+        end
+      end
+
+      context "when class is passed as a constant" do
+        context "when given a string for a name" do
+          it "creates the adapter successfully" do
+            adapter = described_class.create(
+              class: CustomAdapter,
+              name: "custom_adapter",
+              description: "a custom adapter"
+            )
+
+            expect(adapter).to be_a(CustomAdapter)
+            expect(adapter.name).to eq("custom_adapter")
+          end
+        end
+
+        context "when given a symbol for a name" do
+          it "creates the adapter successfully" do
+            adapter = described_class.create(
+              class: CustomAdapter,
+              name: :custom_adapter,
+              description: "a custom adapter"
+            )
+
+            expect(adapter).to be_a(CustomAdapter)
+            expect(adapter.name).to eq("custom_adapter")
+          end
+        end
+      end
+
+      context "when class is passed as a string" do
+        context "when given a string for a name" do
+          it "creates the adapter successfully" do
+            adapter = described_class.create(
+              class: "CustomAdapter",
+              name: "custom_adapter",
+              description: "a custom adapter"
+            )
+
+            expect(adapter).to be_a(CustomAdapter)
+            expect(adapter.name).to eq("custom_adapter")
+          end
+        end
+
+        context "when given a symbol for a name" do
+          it "creates the adapter successfully" do
+            adapter = described_class.create(
+              class: "CustomAdapter",
+              name: :custom_adapter,
+              description: "a custom adapter"
+            )
+
+            expect(adapter).to be_a(CustomAdapter)
+            expect(adapter.name).to eq("custom_adapter")
+          end
+        end
+      end
+    end
+
+    context "error handling" do
+      it "raises an error when neeither type nor class is specified" do
+        expect {
+          described_class.create(
+            name: "error_adapter",
+            description: "This should fail"
+          )
+        }.to raise_error(RuntimeError, "Output adapter must be specified with :class or :type")
+      end
+
+      it "raises an error for invalid class option" do
+        expect {
+          described_class.create(
+            class: 42,
+            name: "error_adapter",
+            description: "This should fail"
+          )
+        }.to raise_error(RuntimeError, "Invalid :class option")
+      end
     end
   end
 end


### PR DESCRIPTION
fixes #39 