### PR TITLE
Add basic loggers to providers

### DIFF
--- a/lib/sublayer.rb
+++ b/lib/sublayer.rb
@@ -10,6 +10,7 @@ require "openai"
 require "nokogiri"
 require "listen"
 require "securerandom"
+require "time"
 
 require_relative "sublayer/version"
 

--- a/lib/sublayer.rb
+++ b/lib/sublayer.rb
@@ -9,6 +9,7 @@ require "httparty"
 require "openai"
 require "nokogiri"
 require "listen"
+require "securerandom"
 
 require_relative "sublayer/version"
 
@@ -22,7 +23,8 @@ module Sublayer
   def self.configuration
     @configuration ||= OpenStruct.new(
       ai_provider: Sublayer::Providers::OpenAI,
-      ai_model: "gpt-4o"
+      ai_model: "gpt-4o",
+      logger: Sublayer::Logging::NullLogger.new
     )
   end
 

--- a/lib/sublayer/logging/base.rb
+++ b/lib/sublayer/logging/base.rb
@@ -1,0 +1,9 @@
+module Sublayer
+  module Logging
+    class Base
+      def log(level, message, data = {})
+        raise NotImplementedError, "Subclasses must implement log method"
+      end
+    end
+  end
+end

--- a/lib/sublayer/logging/debug_logger.rb
+++ b/lib/sublayer/logging/debug_logger.rb
@@ -1,0 +1,10 @@
+module Sublayer
+  module Logging
+    class DebugLogger < Base
+      def log(level, message, data = {})
+        puts "[#{Time.now.iso8601}] #{level.upcase}: #{message}"
+        pp data unless data.empty?
+      end
+    end
+  end
+end

--- a/lib/sublayer/logging/json_logger.rb
+++ b/lib/sublayer/logging/json_logger.rb
@@ -1,0 +1,20 @@
+module Sublayer
+  module Logging
+    class JsonLogger < Base
+      def initialize(log_file = "./tmp/sublayer.log")
+        @log_file = log_file
+      end
+
+      def log(level, message, data = {})
+        File.open(@log_file, "a") do |f|
+          f.puts JSON.generate({
+            timestamp: Time.now.iso8601,
+            level: level,
+            message: message,
+            data: data
+          })
+        end
+      end
+    end
+  end
+end

--- a/lib/sublayer/logging/null_logger.rb
+++ b/lib/sublayer/logging/null_logger.rb
@@ -1,0 +1,9 @@
+module Sublayer
+  module Logging
+    class NullLogger < Base
+      def log(level, message, data = {})
+        # do nothing
+      end
+    end
+  end
+end

--- a/lib/sublayer/providers/claude.rb
+++ b/lib/sublayer/providers/claude.rb
@@ -5,6 +5,15 @@ module Sublayer
   module Providers
     class Claude
       def self.call(prompt:, output_adapter:)
+        request_id = SecureRandom.uuid
+        Sublayer.configuration.logger.log(:info, "Claude API request", {
+          model: Sublayer.configuration.ai_model,
+          prompt: prompt,
+          request_id: request_id
+        });
+
+        before_request = Time.now
+
         response = HTTParty.post(
           "https://api.anthropic.com/v1/messages",
           headers: {
@@ -34,7 +43,22 @@ module Sublayer
 
         raise "Error generating with Claude, error: #{response.body}" unless response.code == 200
 
-        tool_use = JSON.parse(response.body).dig("content").find { |content| content['type'] == 'tool_use' && content['name'] == output_adapter.name }
+        after_request = Time.now
+        response_time = after_request - before_request
+
+        json_response = JSON.parse(response.body)
+
+        Sublayer.configuration.logger.log(:info, "Claude API response", {
+          request_id: request_id,
+          response_time: response_time,
+          usage: {
+            input_tokens: json_response.dig("usage", "input_tokens"),
+            output_tokens: json_response.dig("usage", "output_tokens"),
+            total_tokens: json_response.dig("usage", "input_tokens") + json_response.dig("usage", "output_tokens")
+          }
+        })
+
+        tool_use = json_response.dig("content").find { |content| content['type'] == 'tool_use' && content['name'] == output_adapter.name }
 
         raise "Error generating with Claude, error: No function called. If the answer is in the response, try rewording your prompt or output adapter name to be from the perspective of the model. Response: #{response.body}" unless tool_use
 

--- a/spec/logging/debug_logger_spec.rb
+++ b/spec/logging/debug_logger_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe Sublayer::Logging::DebugLogger do
+  let(:message) { "Test message" }
+  let(:data) { { key: "value" } }
+  let(:logger) { described_class.new }
+
+  it "outputs messages to stdout" do
+    expect {
+      logger.log(:info, message, data)
+    }.to output(/\[.*\] INFO: #{message}/).to_stdout
+  end
+
+  it "pretty prints the data" do
+    expect {
+      logger.log(:info, message, data)
+    }.to output(/\{:key=>"value"\}/).to_stdout
+  end
+end

--- a/spec/logging/json_logger_spec.rb
+++ b/spec/logging/json_logger_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "tempfile"
+
+RSpec.describe Sublayer::Logging::JsonLogger do
+  let(:message) { "Test message" }
+  let(:data) { { key: "value" } }
+  let(:log_file) { Tempfile.new("sublayer_test_log") }
+  let(:logger) { described_class.new(log_file.path) }
+
+  after { log_file.unlink }
+
+  it "logs messages in JSON format" do
+    logger.log(:info, message, data)
+
+    log_content = File.read(log_file.path)
+    log_entry = JSON.parse(log_content)
+
+    expect(log_entry["level"]).to eq("info")
+    expect(log_entry["message"]).to eq(message)
+    expect(log_entry["data"]).to eq(data.stringify_keys)
+    expect(log_entry["timestamp"]).to be_a(String)
+  end
+end

--- a/spec/logging/null_logger_spec.rb
+++ b/spec/logging/null_logger_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Sublayer::Logging::NullLogger do
+  let(:message) { "Test message" }
+  let(:data) { { key: "value" } }
+  let(:logger) { described_class.new }
+
+  it "does not produce any output" do
+    expect {
+      logger.log(:info, message, data)
+    }.not_to output.to_stdout
+  end
+end

--- a/spec/providers/gemini_spec.rb
+++ b/spec/providers/gemini_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+RSpec.describe Sublayer::Providers::Gemini do
+  let(:basic_output_adapter) {
+    Sublayer::Components::OutputAdapters.create(
+      type: :single_string,
+      name: "the_answer",
+      description: "The answer to the given question"
+    ).extend(Sublayer::Components::OutputAdapters::Formattable)
+  }
+
+  before do
+    Sublayer.configuration.ai_provider = described_class
+    Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
+  end
+
+  xdescribe "#call" do
+    it "calls the Gemini API" do
+      VCR.use_cassette("gemini/42") do
+        response = described_class.call(
+          prompt: "What is the meaning of life, the universe, and everything?",
+          output_adapter: basic_output_adapter
+        )
+
+        expect(response).to be_a(String)
+        expect(response.length).to be > 0
+      end
+
+      context "logging" do
+        let(:mock_logger) { instance_double(Sublayer::Logging::Base) }
+
+        before do
+          Sublayer.configuration.logger = mock_logger
+        end
+
+        after do
+          Sublayer.configuration.logger = Sublayer::Logging::NullLogger.new
+        end
+
+        it "logs the request and response" do
+          expect(mock_logger).to receive(:log).with(:info, "Gemini API request", hash_including(:model, :prompt))
+          expect(mock_logger).to receive(:log).with(:info, "Gemini API response", instance_of(Hash))
+
+          VCR.use_cassette("gemini/42") do
+            described_class.call(
+              prompt: "What is the meaning of life, the universe, and everything?",
+              output_adapter: basic_output_adapter
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/gemini/42.yml
+++ b/spec/vcr_cassettes/gemini/42.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=<GEMINI_API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"contents":{"role":"user","parts":{"text":"What is the meaning of
+        life, the universe, and everything?"}},"tools":[{"function_declarations":[{"name":"the_answer","description":"The
+        answer to the given question","parameters":{"type":"OBJECT","properties":{"the_answer":{"type":"string","description":"The
+        answer to the given question"}},"required":["the_answer"]}}]}],"tool_config":{"function_calling_config":{"mode":"ANY","allowed_function_names":["the_answer"]}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sun, 11 Aug 2024 21:07:52 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - gfet4t7; dur=276
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "error": {
+            "code": 500,
+            "message": "An internal error has occurred. Please retry or report in https://developers.generativeai.google/guide/troubleshooting",
+            "status": "INTERNAL"
+          }
+        }
+  recorded_at: Sun, 11 Aug 2024 21:07:52 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
References #56

Add basic logging for provider inputs and outputs.

Added 3 different loggers:
- a default `NullLogger` for 0.2.2 so that this isn't a breaking release
- a `DebugLogger` which outputs the messages to stdout
- a `JsonLogger` which outputs the messages to a local `./tmp/sublayer.log` file by default or can be instantiated with whichever file path you'd like. 

To use the different loggers you can change your configuration the same way you do for different models and providers. A new `Sublayer.configuration.logger` accepts an instance of a logger you want, so to use the JsonLogger you'd use `Sublayer.configuration.logger = Sublayer::Loggers::JsonLogger.new('./my_file_path')`