### PR TITLE
Add new named_strings output adapter

### DIFF
--- a/lib/sublayer/components/output_adapters/named_strings.rb
+++ b/lib/sublayer/components/output_adapters/named_strings.rb
@@ -1,0 +1,31 @@
+module Sublayer
+  module Components
+    module OutputAdapters
+      class NamedStrings
+        attr_reader :name, :description, :attributes
+
+        def initialize(options)
+          @name = options[:name]
+          @description = options[:description]
+          @attributes = options[:attributes]
+        end
+
+        def properties
+          [
+            OpenStruct.new(
+              name: @name,
+              type: "object",
+              description: @description,
+              required: true,
+              properties: @attributes.map { |attribute| OpenStruct.new(type: "string", description: attribute[:description], required: true, name: attribute[:name]) }
+            )
+          ]
+        end
+
+        def materialize_result(raw_result)
+          OpenStruct.new( @attributes.map { |attribute| [attribute[:name], raw_result[attribute[:name]]] }.to_h)
+        end
+      end
+    end
+  end
+end

--- a/lib/sublayer/generators/base.rb
+++ b/lib/sublayer/generators/base.rb
@@ -10,7 +10,10 @@ module Sublayer
 
       def generate
         self.class::OUTPUT_ADAPTER.load_instance_data(self) if self.class::OUTPUT_ADAPTER.respond_to?(:load_instance_data)
-        @results = Sublayer.configuration.ai_provider.call(prompt: prompt, output_adapter: self.class::OUTPUT_ADAPTER)
+
+        raw_results = Sublayer.configuration.ai_provider.call(prompt: prompt, output_adapter: self.class::OUTPUT_ADAPTER)
+
+        @results = self.class::OUTPUT_ADAPTER.respond_to?(:materialize_result) ? self.class::OUTPUT_ADAPTER.materialize_result(raw_results) : raw_results
       end
     end
   end

--- a/spec/components/output_adapters/named_strings_spec.rb
+++ b/spec/components/output_adapters/named_strings_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+RSpec.describe Sublayer::Components::OutputAdapters::NamedStrings do
+  let(:name) { 'test_adapter' }
+  let(:description) { 'Test adapter description' }
+
+  let(:attributes) do
+    [
+      { name: "field1", description: "Description of field1" },
+      { name: "field2", description: "Description of field2" }
+    ]
+  end
+
+  let(:output_adapter) { described_class.new(name: name, description: description, attributes: attributes) }
+
+  describe "#initialize" do
+    it "sets the name, description, and attributes" do
+      expect(output_adapter.name).to eq(name)
+      expect(output_adapter.description).to eq(description)
+      expect(output_adapter.attributes).to eq(attributes)
+    end
+  end
+
+  describe "#properties" do
+    it "returns an array with one OpenStruct object" do
+      properties = output_adapter.properties
+      expect(properties).to be_an(Array)
+      expect(properties.size).to eq(1)
+      expect(properties.first).to be_an(OpenStruct)
+    end
+
+    it "sets the correct attributes for the main property" do
+      property = output_adapter.properties.first
+      expect(property.name).to eq(name)
+      expect(property.description).to eq(description)
+      expect(property.required).to eq(true)
+      expect(property.type).to eq("object")
+    end
+
+    it "sets the correct nested properties" do
+      nested_properties = output_adapter.properties.first.properties
+      expect(nested_properties[0].name).to eq("field1")
+      expect(nested_properties[0].type).to eq("string")
+      expect(nested_properties[0].description).to eq("Description of field1")
+      expect(nested_properties[0].required).to eq(true)
+      expect(nested_properties[1].name).to eq("field2")
+      expect(nested_properties[1].type).to eq("string")
+      expect(nested_properties[1].description).to eq("Description of field2")
+      expect(nested_properties[1].required).to eq(true)
+    end
+  end
+end

--- a/spec/generators/code_from_description_generator_spec.rb
+++ b/spec/generators/code_from_description_generator_spec.rb
@@ -1,4 +1,3 @@
-require "pry"
 require "spec_helper"
 
 require "generators/examples/code_from_description_generator"
@@ -25,17 +24,18 @@ RSpec.describe CodeFromDescriptionGenerator do
         expect(code.strip).to include("puts \"Hello, \#{")
       end
     end
+  end
 
-    context "openai" do
-      before do
-        Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
-        Sublayer.configuration.ai_model = "gpt-4-turbo"
-      end
+  context "openai" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+      Sublayer.configuration.ai_model = "gpt-4-turbo"
+    end
 
-      it "generates code from description" do
-        VCR.use_cassette("openai/generators/code_from_description_generator/hello_world") do
-          code = generate(description: "a hello world app where I pass --who argument to set the 'world' value using optparser")
-          expect(code.strip).to eq %q(require 'optparse'
+    it "generates code from description" do
+      VCR.use_cassette("openai/generators/code_from_description_generator/hello_world") do
+        code = generate(description: "a hello world app where I pass --who argument to set the 'world' value using optparser")
+        expect(code.strip).to eq %q(require 'optparse'
 
 # Define the options
 options = {}
@@ -50,21 +50,21 @@ end.parse!
 # Greeting
 who_to_greet = options[:who] || "World"
 puts "Hello, #{who_to_greet}!")
-        end
       end
-
     end
 
-    xcontext "Gemini" do
-      before do
-        Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
-        Sublayer.configuration.ai_model = "gemini-pro"
-      end
+  end
 
-      it "generates code from description" do
-        VCR.use_cassette("gemini/generators/code_from_description_generator/hello_world") do
-          code = generate(description: "a hello world app where I pass --who argument to set the 'world' value using optparser")
-          expect(code.strip).to eq %q(#!/usr/bin/env ruby
+  xcontext "Gemini" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+      Sublayer.configuration.ai_model = "gemini-pro"
+    end
+
+    it "generates code from description" do
+      VCR.use_cassette("gemini/generators/code_from_description_generator/hello_world") do
+        code = generate(description: "a hello world app where I pass --who argument to set the 'world' value using optparser")
+        expect(code.strip).to eq %q(#!/usr/bin/env ruby
 
 require 'optparse'
 
@@ -76,7 +76,6 @@ OptionParser.new do |opts|
 end.parse!
 
 puts "Hello, #{options[:who]}!")
-        end
       end
     end
   end

--- a/spec/generators/examples/product_description_generator.rb
+++ b/spec/generators/examples/product_description_generator.rb
@@ -1,0 +1,35 @@
+class ProductDescriptionGenerator < Sublayer::Generators::Base
+  llm_output_adapter type: :named_strings,
+    name: "product_description",
+    description: "Generate product descriptions",
+    attributes: [
+      { name: "short_description", description: "A brief one-sentence description of the product" },
+      { name: "long_description", description: "A detailed paragraph describing the product" },
+      { name: "key_features", description: "A comma-separated list of key product features" },
+      { name: "target_audience", description: "A brief description of the target audience for this product" }
+    ]
+
+  def initialize(product_name:, product_category:)
+    @product_name = product_name
+    @product_category = product_category
+  end
+
+  def generate
+    super
+  end
+
+  def prompt
+    <<-PROMPT
+    You are a skilled product copywriter. Create compelling product descriptions for the following:
+
+    Product Name: #{@product_name}
+    Product Category: #{@product_category}
+
+    Please provide the following:
+    1. A brief one-sentence description of the product
+    2. A detailed paragraph describing the product
+    3. A comma-separated list of key product features
+    4. A brief description of the target audience for this product
+    PROMPT
+  end
+end

--- a/spec/generators/product_description_generator_spec.rb
+++ b/spec/generators/product_description_generator_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+require "pry"
+
+require "generators/examples/product_description_generator"
+
+RSpec.describe ProductDescriptionGenerator do
+  def generate
+    described_class.new(product_name: "Super Gadget", product_category: "Electronics").generate
+  end
+
+  context "OpenAI" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+      Sublayer.configuration.ai_model = "gpt-4o"
+    end
+
+    it "generates an with the correct keys" do
+      VCR.use_cassette("openai/generators/product_description_generator/super_gadget") do
+        result = generate
+        expect(result).to respond_to(:short_description)
+        expect(result).to respond_to(:long_description)
+        expect(result).to respond_to(:key_features)
+        expect(result).to respond_to(:target_audience)
+      end
+    end
+  end
+
+  context "Claude" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+      Sublayer.configuration.ai_model = "claude-3-haiku-20240307"
+    end
+
+    it "generates an with the correct keys" do
+      VCR.use_cassette("claude/generators/product_description_generator/super_gadget") do
+        result = generate
+        expect(result).to respond_to(:short_description)
+        expect(result).to respond_to(:long_description)
+        expect(result).to respond_to(:key_features)
+        expect(result).to respond_to(:target_audience)
+      end
+    end
+
+  end
+
+  xcontext "Gemini" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+      Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
+    end
+
+    it "generates an with the correct keys" do
+      VCR.use_cassette("gemini/generators/product_description_generator/super_gadget") do
+        result = generate
+        expect(result).to respond_to(:short_description)
+        expect(result).to respond_to(:long_description)
+        expect(result).to respond_to(:key_features)
+        expect(result).to respond_to(:target_audience)
+      end
+    end
+
+  end
+end

--- a/spec/vcr_cassettes/claude/generators/product_description_generator/super_gadget.yml
+++ b/spec/vcr_cassettes/claude/generators/product_description_generator/super_gadget.yml
@@ -1,0 +1,92 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"model":"claude-3-haiku-20240307","max_tokens":4096,"tools":[{"name":"product_description","description":"Generate
+        product descriptions","input_schema":{"type":"object","properties":{"product_description":{"type":"object","description":"Generate
+        product descriptions","properties":{"short_description":{"type":"string","description":"A
+        brief one-sentence description of the product"},"long_description":{"type":"string","description":"A
+        detailed paragraph describing the product"},"key_features":{"type":"string","description":"A
+        comma-separated list of key product features"},"target_audience":{"type":"string","description":"A
+        brief description of the target audience for this product"}}}},"required":["product_description"]}}],"tool_choice":{"type":"tool","name":"product_description"},"messages":[{"role":"user","content":"    You
+        are a skilled product copywriter. Create compelling product descriptions for
+        the following:\n\n    Product Name: Super Gadget\n    Product Category: Electronics\n\n    Please
+        provide the following:\n    1. A brief one-sentence description of the product\n    2.
+        A detailed paragraph describing the product\n    3. A comma-separated list
+        of key product features\n    4. A brief description of the target audience
+        for this product\n"}]}'
+    headers:
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Content-Type:
+      - application/json
+      Anthropic-Beta:
+      - tools-2024-04-04
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 13 Aug 2024 16:58:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Requests-Limit:
+      - '1000'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '999'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2024-08-13T16:58:34Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '100000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '100000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2024-08-13T16:58:01Z'
+      Request-Id:
+      - req_01KKvSschHrTvGWY7kTSAEn8
+      X-Cloud-Trace-Context:
+      - 03e4ce455e3ef12b6521e02ceba69878
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8b2a3f521a29c342-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"msg_01X6eRxF8Jp926yZ4w38F8jj","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[{"type":"tool_use","id":"toolu_01AFvhZWWmBb7tnWQVeciuhn","name":"product_description","input":{"product_description":{"short_description":"The
+        Super Gadget is an innovative electronic device that revolutionizes the way
+        you interact with technology.","long_description":"Introducing the Super Gadget,
+        a groundbreaking electronic device that redefines the boundaries of what''s
+        possible. This cutting-edge gadget seamlessly integrates advanced functionality,
+        sleek design, and user-friendly features to enhance your daily digital experiences.
+        Whether you''re a tech enthusiast, a busy professional, or simply someone
+        who appreciates the latest innovations, the Super Gadget is your gateway to
+        a smarter, more efficient future.","key_features":"Intuitive touch interface,
+        Powerful dual-core processor, Wireless charging, Built-in virtual assistant,
+        Customizable settings","target_audience":"The Super Gadget caters to a wide
+        range of tech-savvy individuals, from millennials to tech-savvy professionals,
+        who demand the latest advancements in electronic devices and seek to streamline
+        their digital lives."}}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":624,"output_tokens":261}}'
+  recorded_at: Tue, 13 Aug 2024 16:58:01 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/gemini/generators/product_description_generator/super_gadget.yml
+++ b/spec/vcr_cassettes/gemini/generators/product_description_generator/super_gadget.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=<GEMINI_API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"contents":{"role":"user","parts":{"text":"    You are a skilled product
+        copywriter. Create compelling product descriptions for the following:\n\n    Product
+        Name: Super Gadget\n    Product Category: Electronics\n\n    Please provide
+        the following:\n    1. A brief one-sentence description of the product\n    2.
+        A detailed paragraph describing the product\n    3. A comma-separated list
+        of key product features\n    4. A brief description of the target audience
+        for this product\n"}},"tools":[{"function_declarations":[{"name":"product_description","description":"Generate
+        product descriptions","parameters":{"type":"OBJECT","properties":{"product_description":{"type":"object","description":"Generate
+        product descriptions","properties":{"short_description":{"type":"string","description":"A
+        brief one-sentence description of the product"},"long_description":{"type":"string","description":"A
+        detailed paragraph describing the product"},"key_features":{"type":"string","description":"A
+        comma-separated list of key product features"},"target_audience":{"type":"string","description":"A
+        brief description of the target audience for this product"}}}},"required":["product_description"]}}]}],"tool_config":{"function_calling_config":{"mode":"ANY","allowed_function_names":["product_description"]}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 13 Aug 2024 16:57:10 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - gfet4t7; dur=391
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "error": {
+            "code": 500,
+            "message": "An internal error has occurred. Please retry or report in https://developers.generativeai.google/guide/troubleshooting",
+            "status": "INTERNAL"
+          }
+        }
+  recorded_at: Tue, 13 Aug 2024 16:57:10 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/openai/generators/product_description_generator/super_gadget.yml
+++ b/spec/vcr_cassettes/openai/generators/product_description_generator/super_gadget.yml
@@ -1,0 +1,121 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"    You are
+        a skilled product copywriter. Create compelling product descriptions for the
+        following:\n\n    Product Name: Super Gadget\n    Product Category: Electronics\n\n    Please
+        provide the following:\n    1. A brief one-sentence description of the product\n    2.
+        A detailed paragraph describing the product\n    3. A comma-separated list
+        of key product features\n    4. A brief description of the target audience
+        for this product\n"}],"tool_choice":{"type":"function","function":{"name":"product_description"}},"tools":[{"type":"function","function":{"name":"product_description","description":"Generate
+        product descriptions","parameters":{"type":"object","properties":{"product_description":{"type":"object","description":"Generate
+        product descriptions","properties":{"short_description":{"type":"string","description":"A
+        brief one-sentence description of the product"},"long_description":{"type":"string","description":"A
+        detailed paragraph describing the product"},"key_features":{"type":"string","description":"A
+        comma-separated list of key product features"},"target_audience":{"type":"string","description":"A
+        brief description of the target audience for this product"}}}}},"required":["product_description"]}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 13 Aug 2024 16:57:16 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Organization:
+      - sublayer
+      Openai-Processing-Ms:
+      - '5135'
+      Openai-Version:
+      - '2020-10-01'
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '2000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '1999876'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 3ms
+      X-Request-Id:
+      - req_a2609d47efd3d93efb4b49f732f80cf3
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=7Ica4pVcKjtC87CDqFWe9ACh5nnru2ZtPKDEzgZu07I-1723568236-1.0.1.1-vNRQTKeJjVisZPMxaiPnk4CttN79OHcvpiiAEs0nbPUM3aV.kgYdSe76scUSoX76JqCnq2gOKKLTZmbpLJWIyw;
+        path=/; expires=Tue, 13-Aug-24 17:27:16 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=LmqaMgx9YJL8j2hpt5srCyNGXHA75S9A6YHD9mlWYjU-1723568236196-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8b2a3e22cd2b41d3-EWR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-9vp7XvcmCFU7p7BOOHiSrMJEowJJh",
+          "object": "chat.completion",
+          "created": 1723568231,
+          "model": "gpt-4o-2024-05-13",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                  {
+                    "id": "call_drxKY5ciXdx4F9glwtn9qk2I",
+                    "type": "function",
+                    "function": {
+                      "name": "product_description",
+                      "arguments": "{\"product_description\":{\"short_description\":\"Revolutionize your daily tasks with the cutting-edge Super Gadget.\",\"long_description\":\"The Super Gadget is the ultimate electronic companion designed to make your life easier, more efficient, and enjoyable. Whether you need it for work, leisure, or staying connected, this all-in-one device combines advanced technology with user-friendly features. Boasting a sleek design and robust performance, the Super Gadget seamlessly integrates with your daily routine, offering unparalleled functionality at your fingertips. With its long battery life, high-definition display, and intuitive interface, this gadget is perfect for tech enthusiasts and casual users alike. Embrace the future of convenience with the Super Gadget and transform the way you interact with technology.\",\"key_features\":\"sleek design, robust performance, long battery life, high-definition display, intuitive interface, all-in-one functionality\",\"target_audience\":\"tech enthusiasts, casual users, busy professionals, students, gadget lovers\"}}"
+                    }
+                  }
+                ],
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 203,
+            "completion_tokens": 186,
+            "total_tokens": 389
+          },
+          "system_fingerprint": "fp_3aa7262c27"
+        }
+  recorded_at: Tue, 13 Aug 2024 16:57:16 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
New output adapter to return an object with named string attributes. This is useful for when you want to extract a few different types of strings from a text or want to construct an object based on a prompt.

For example, say you have a product with some attributes and you want to generate a short description, long description, key features, and target audience.  Or have a blog post and want to extract the key ideas, major points, summary, and followup questions.

As part of this change we've also introduced some post-processing for results where you can optionally add `materialize_result(raw_results)` to your output_adapter and return a better formatted object or attribute to your generator.