### PR TITLE
Add quick_script template

### DIFF
--- a/lib/sublayer/templates/cli/README.md
+++ b/lib/sublayer/templates/cli/README.md
@@ -17,7 +17,6 @@ $ bin/PROJECT_NAME
 ```
 
 Available commands:
-- `example`: Run the example agent
-- `generate`: Run the example generator
+- `example`: Run the example generator
 - `help`: Display the help message
 

--- a/lib/sublayer/templates/quick_script/README.md
+++ b/lib/sublayer/templates/quick_script/README.md
@@ -1,0 +1,16 @@
+# ProjectName
+
+Welcome to your new Sublayer quick script project!
+
+There are example Agents, Generators, and Actions in the respective folders.
+
+## Usage
+
+Create your own custom agents, generators, and actions and use them in
+`project_name.rb`
+
+Run your script:
+
+```
+$ ruby project_name.rb
+```

--- a/lib/sublayer/templates/quick_script/actions/example_action.rb
+++ b/lib/sublayer/templates/quick_script/actions/example_action.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ExampleAction < Sublayer::Actions::Base
+  def initialize(input:)
+    @input = input
+  end
+
+  def call
+    puts "Performing action with input: #{@input}"
+  end
+end

--- a/lib/sublayer/templates/quick_script/agents/example_agent.rb
+++ b/lib/sublayer/templates/quick_script/agents/example_agent.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ExampleAgent < Sublayer::Agents::Base
+  trigger_on_files_changed { ["example_file.txt"] }
+
+  goal_condition { @goal_reached }
+
+  check_status do
+    @status_checked = true
+  end
+
+  step do
+    @step_taken = true
+    @goal_reached = true
+    puts "Example agent step executed"
+  end
+end

--- a/lib/sublayer/templates/quick_script/generators/example_generator.rb
+++ b/lib/sublayer/templates/quick_script/generators/example_generator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ExampleGenerator < Sublayer::Generators::Base
+  llm_output_adapter type: :single_string,
+    name: "generated_text",
+    description: "A simple generated text"
+
+  def initialize(input:)
+    @input = input
+  end
+
+  def generate
+    super
+  end
+
+  def prompt
+    <<-PROMPT
+          Generate a simple story based on this input: #{@input}
+    PROMPT
+  end
+end

--- a/lib/sublayer/templates/quick_script/project_name.rb
+++ b/lib/sublayer/templates/quick_script/project_name.rb
@@ -1,0 +1,7 @@
+require "yaml"
+require "sublayer"
+
+Dir[File.join(__dir__, "actions", "*.rb")].each { |file| require file }
+Dir[File.join(__dir__, "agents", "*.rb")].each { |file| require file }
+Dir[File.join(__dir__, "generators", "*.rb")].each { |file| require file }
+

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Sublayer::CLI do
   before do
     allow(TTY::Prompt).to receive(:new).and_return(prompt)
     allow(prompt).to receive(:ask).and_return("test_project")
-    allow(prompt).to receive(:select).and_return("Web Service", "OpenAI")
+    allow(prompt).to receive(:select).and_return("CLI", "OpenAI")
     allow(prompt).to receive(:yes?).and_return(false)
   end
 
@@ -32,7 +32,7 @@ RSpec.describe Sublayer::CLI do
 
     describe "#create_new_project" do
       it "creates a new project with the given name" do
-        expect(FileUtils).to receive(:mkdir_p)
+        expect(FileUtils).to receive(:mkdir_p).twice
         expect(FileUtils).to receive(:cp_r)
         expect(TTY::File).to receive(:create_file)
         expect(cli).to receive(:replace_placeholders)

--- a/spec/integration/quick_script_creation_spec.rb
+++ b/spec/integration/quick_script_creation_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require "fileutils"
+require "open3"
+require "tmpdir"
+
+TMP_DIR = ENV['RUNNER_TEMP'] || Dir.tmpdir
+
+RSpec.describe "Quick Script Project Creation" do
+  let(:project_name) { "test_project" }
+  let(:project_path) { File.join(TMP_DIR, project_name) }
+
+  before(:all) do
+    FileUtils.mkdir_p(TMP_DIR)
+  end
+
+  after(:all) do
+    FileUtils.rm_rf(TMP_DIR)
+  end
+
+  after(:each) do
+    FileUtils.rm_rf(project_path)
+  end
+
+  it "creates a new project with all the expected files and structures" do
+    command = "ruby -I lib #{File.dirname(__FILE__)}/../../bin/sublayer new #{project_name}"
+    input = "\e[B\n\n\nn\n\n"
+
+    output, status = Open3.capture2e(command, chdir: TMP_DIR, stdin_data: input)
+
+    expect(status.success?).to be true
+    expect(output).to include("Sublayer project '#{project_name}' created successfully!")
+
+    expect(Dir.exist?(project_path)).to be true
+
+    %w[
+      test_project.rb
+      agents/example_agent.rb
+      generators/example_generator.rb
+      actions/example_action.rb
+      README.md
+    ].each do |file|
+      expect(File.exist?(File.join(project_path, file))).to be true
+    end
+  end
+end


### PR DESCRIPTION
Added another template, this one for if you're just looking to put something together quickly to play around with in a single ruby file. Loads any agents, generators, or actions into `project_name.rb`.

Starting to reach the limits of the `cli.rb` script and the mechanism for replacing the placeholders. Probably need to switch over to similar to using thor instead of tty and doing something similar to how rails does it. Maybe with erb templates for these files even?

Tracking research on these questions here https://github.com/sublayerapp/sublayer/issues/77