### PR TITLE
Generating generators

### DIFF
--- a/lib/sublayer/cli.rb
+++ b/lib/sublayer/cli.rb
@@ -1,19 +1,56 @@
 require "thor"
+
+require "sublayer"
 require "sublayer/version"
 require "yaml"
 require "fileutils"
 require "active_support/inflector"
 
+require_relative "cli/commands/subcommand_base"
 require_relative "cli/commands/new_project"
+require_relative "cli/commands/generate"
 
 module Sublayer
   class CLI < Thor
 
     register(Sublayer::Commands::NewProject, "new", "new PROJECT_NAME", "Creates a new Sublayer project")
 
+    desc "generate", "Generate Sublayer Actions, Generators, and Agents with an LLM"
+    subcommand "generate", Sublayer::Commands::Generate
+
     desc "version", "Prints the Sublayer version"
     def version
       puts Sublayer::VERSION
+    end
+
+    desc "help [COMMAND]", "Describe available commands or one specific command"
+    def help(command = nil, subcommand = false)
+      if command.nil?
+        puts "Sublayer CLI"
+        puts
+        puts "Usage:"
+        puts "  sublayer COMMAND [OPTIONS]"
+        puts
+        puts "Commands:"
+        print_commands(self.class.commands.reject { |name, _| name == "help" || name == "version" })
+        puts
+        print_commands(self.class.commands.select { |name, _| name == "help" })
+        print_commands(self.class.commands.select { |name, _| name == "version" })
+        puts
+        puts "Run 'sublayer COMMAND --help' for more information on a command."
+      else
+        super
+      end
+    end
+
+    default_command :help
+
+    private
+
+    def print_commands(commands)
+      commands.each do |name, command|
+        puts "  #{name.ljust(15)} # #{command.description}"
+      end
     end
   end
 end

--- a/lib/sublayer/cli/commands/generate.rb
+++ b/lib/sublayer/cli/commands/generate.rb
@@ -1,0 +1,11 @@
+require_relative "./generator"
+
+module Sublayer
+  module Commands
+    class Generate < SubCommandBase
+
+      register(Sublayer::Commands::Generator, "generator", "generator DESCRIPTION", "Generates a new generator")
+
+    end
+  end
+end

--- a/lib/sublayer/cli/commands/generate.rb
+++ b/lib/sublayer/cli/commands/generate.rb
@@ -3,9 +3,7 @@ require_relative "./generator"
 module Sublayer
   module Commands
     class Generate < SubCommandBase
-
-      register(Sublayer::Commands::Generator, "generator", "generator DESCRIPTION", "Generates a new generator")
-
+      register(Sublayer::Commands::Generator, "generator", "generator", "Generates a new Sublayer::Generator subclass for your project")
     end
   end
 end

--- a/lib/sublayer/cli/commands/generator.rb
+++ b/lib/sublayer/cli/commands/generator.rb
@@ -5,7 +5,6 @@ module Sublayer
     class Generator < Thor::Group
       include Thor::Actions
 
-
       class_option :description, type: :string, desc: "Description of the generator you want to generate", aliases: :d
       class_option :provider, type: :string, desc: "AI provider (OpenAI, Claude, or Gemini)", aliases: :p
       class_option :model, type: :string, desc: "AI model name to use (e.g. gpt-4o, claude-3-haiku-20240307, gemini-1.5-flash-latest)", aliases: :m

--- a/lib/sublayer/cli/commands/generator.rb
+++ b/lib/sublayer/cli/commands/generator.rb
@@ -34,6 +34,7 @@ module Sublayer
         Sublayer.configuration.ai_provider = Object.const_get("Sublayer::Providers::#{@ai_provider}")
         Sublayer.configuration.ai_model = @ai_model
 
+        say "Generating Sublayer Generator..."
         @results = SublayerGeneratorGenerator.new(description: @description).generate
       end
 

--- a/lib/sublayer/cli/commands/generator.rb
+++ b/lib/sublayer/cli/commands/generator.rb
@@ -1,0 +1,68 @@
+require_relative "generators/sublayer_generator_generator"
+
+module Sublayer
+  module Commands
+    class Generator < Thor::Group
+      include Thor::Actions
+
+
+      class_option :description, type: :string, desc: "Description of the generator you want to generate", aliases: :d
+      class_option :provider, type: :string, desc: "AI provider (OpenAI, Claude, or Gemini)", aliases: :p
+      class_option :model, type: :string, desc: "AI model name to use (e.g. gpt-4o, claude-3-haiku-20240307, gemini-1.5-flash-latest)", aliases: :m
+
+      def confirm_usage_of_ai_api
+        puts "You are about to generate a new generator that uses an AI API to generate content."
+        puts "Please ensure you have the necessary API keys and that you are aware of the costs associated with using the API."
+        exit unless yes?("Do you want to continue?")
+      end
+
+      def determine_available_providers
+        @available_providers = []
+
+        @available_providers << "OpenAI" if ENV["OPENAI_API_KEY"]
+        @available_providers << "Claude" if ENV["ANTHROPIC_API_KEY"]
+        @available_providers << "Gemini" if ENV["GEMINI_API_KEY"]
+      end
+
+      def ask_for_generator_details
+        @description = options[:description] || ask("Enter a description for the Sublayer Generator you'd like to create:")
+        @ai_provider = options[:provider] || ask("Select an AI provider:", default: "OpenAI", limited_to: @available_providers)
+        @ai_model = options[:model] || select_ai_model
+      end
+
+      def generate_generator
+        Sublayer.configuration.ai_provider = Object.const_get("Sublayer::Providers::#{@ai_provider}")
+        Sublayer.configuration.ai_model = @ai_model
+
+        @results = SublayerGeneratorGenerator.new(description: @description).generate
+      end
+
+      def determine_destination_folder
+        # Find either a ./generators folder or a generators folder nested one level below ./lib
+        @destination_folder = if File.directory?("./generators")
+                                "./generators"
+                              elsif Dir.glob("./lib/**/generators").any?
+                                Dir.glob("./lib/**/generators").first
+                              else
+                                "./"
+                              end
+      end
+
+      def save_generator_to_destination_folder
+        create_file File.join(@destination_folder, @results.filename), @results.code
+      end
+
+      private
+      def select_ai_model
+        case @ai_provider
+        when "OpenAI"
+          ask("Which OpenAI model would you like to use?", default: "gpt-4o")
+        when "Claude"
+          ask("Which Anthropic model would you like to use?", default: "claude-3-5-sonnet-20240620")
+        when "Gemini"
+          ask("Which Google model would you like to use?", default: "gemini-1.5-flash-latest")
+        end
+      end
+    end
+  end
+end

--- a/lib/sublayer/cli/commands/generators/example_generator.rb
+++ b/lib/sublayer/cli/commands/generators/example_generator.rb
@@ -1,0 +1,26 @@
+class CodeFromDescriptionGenerator < Sublayer::Generators::Base
+  llm_output_adapter type: :single_string,
+    name: "generated_code",
+    description: "The generated code in the requested language"
+
+  def initialize(description:, technologies:)
+    @description = description
+    @technologies = technologies
+  end
+
+  def generate
+    super
+  end
+
+  def prompt
+    <<-PROMPT
+        You are an expert programmer in #{@technologies.join(", ")}.
+
+        You are tasked with writing code using the following technologies: #{@technologies.join(", ")}.
+
+        The description of the task is #{@description}
+
+        Take a deep breath and think step by step before you start coding.
+    PROMPT
+  end
+end

--- a/lib/sublayer/cli/commands/generators/sublayer_generator_generator.rb
+++ b/lib/sublayer/cli/commands/generators/sublayer_generator_generator.rb
@@ -1,0 +1,96 @@
+class SublayerGeneratorGenerator < Sublayer::Generators::Base
+  llm_output_adapter type: :named_strings,
+    name: "sublayer_generator",
+    description: "The new Sublayer generator code based on the description",
+    attributes: [
+      { name: "code", description: "The code of the generated Sublayer generator" },
+      { name: "filename", description: "The filename of the generated Sublayer generator camel cased and with a .rb extension" }
+    ]
+
+  def initialize(description:)
+    @description = description
+  end
+
+  def generate
+    super
+  end
+
+  def prompt
+    <<-PROMPT
+    You are an expert ruby programmer and and great at repurposing code examples to use for new situations.
+
+    A Sublayer generator is a class that acts as an abstraction for sending a request to an LLM and getting structured data back.
+
+    An example Sublayer generator is:
+    <example_generator>
+    #{example_generator}
+    </example_generator>
+
+    And it is the generator we're currently using for taking in a description from a user and generating a new Sublayer generator.
+
+    All Sublayer::Generators inherit from Sublayer::Generators::Base and have a generate method that simply calls super for the user to use and modify for their uses.
+
+    the llm_output_adapter directive is used to instruct the LLM on what structure of output to generate. In the example we're using type: :single_string which takes a name and description as arguments.
+
+    the other available options and their example usage is:
+    llm_output_adapter type: :list_of_strings,
+      name: "suggestions",
+      description: "List of keyword suggestions"
+
+    llm_output_adapter type: :single_integer,
+      name: "four_digit_passcode",
+      description: "an uncommon and difficult to guess four digit passcode"
+
+    llm_output_adapter type: :list_of_named_strings,
+      name: "review_summaries",
+      description: "List of movie reviews",
+      item_name: "review",
+      attributes: [
+        { name: "movie_title", description: "The title of the movie" },
+        { name: "reviewer_name", description: "The name of the reviewer" },
+        { name: "rating", description: "The rating given by the reviewer (out of 5 stars)" },
+        { name: "brief_comment", description: "A brief summary of the movie" }
+      ]
+
+    llm_output_adapter type: :named_strings,
+      name: "product_description",
+      description: "Generate product descriptions",
+      attributes: [
+        { name: "short_description", description: "A brief one-sentence description of the product" },
+        { name: "long_description", description: "A detailed paragraph describing the product" },
+        { name: "key_features", description: "A comma-separated list of key product features" },
+        { name: "target_audience", description: "A brief description of the target audience for this product" }
+      ]
+
+    # Where :available_routes is a method that returns an array of available routes
+    llm_output_adapter type: :string_selection_from_list,
+      name: "route",
+      description: "A route selected from the list",
+      options: :available_routes
+
+    # Where @sentiment_options is an array of sentiment values passed in to the initializer
+    llm_output_adapter type: :string_selection_from_list,
+      name: "sentiment_value",
+      description: "A sentiment value from the list",
+      options: -> { @sentiment_options }
+
+    Besides that, a Sublayer::Generator also has a prompt method that describes the task to the LLM and provides any necessary context for the generation which
+    is either passed in through the initializer or accessed in the prompt itself.
+
+    You have a description provided by the user to generate a new sublayer generator.
+
+    You are tasked with creating a new sublayer generator according to the given description.
+
+    Consider the details and requirements mentioned in the description to create the appropriate Sublayer::Generator.
+    <users_description>
+    #{@description}
+    </users_description>
+
+    Take a deep breath and reflect on each aspect of the description before proceeding with the generation.
+    PROMPT
+  end
+
+  def example_generator
+    File.read(File.join(File.dirname(__FILE__), "example_generator.rb"))
+  end
+end

--- a/lib/sublayer/cli/commands/subcommand_base.rb
+++ b/lib/sublayer/cli/commands/subcommand_base.rb
@@ -1,0 +1,13 @@
+module Sublayer
+  module Commands
+    class SubCommandBase < Thor
+      def self.banner(command, namespace = nil, subcommand = false)
+        "#{basename} #{subcommand_prefix} #{command.usage}"
+      end
+
+      def self.subcommand_prefix
+        self.name.gsub(%r{.*::}, '').gsub(%r{^[A-Z]}) { |match| match[0].downcase }.gsub(%r{[A-Z]}) { |match| "-#{match[0].downcase}" }
+      end
+    end
+  end
+end

--- a/spec/cli/generators/generator_generator_spec.rb
+++ b/spec/cli/generators/generator_generator_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+require_relative "../../../lib/sublayer/cli/commands/generators/sublayer_generator_generator"
+
+RSpec.describe SublayerGeneratorGenerator do
+  def generate(description)
+    described_class.new(description: description).generate
+  end
+
+  context "Claude" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+      Sublayer.configuration.ai_model = "claude-3-haiku-20240307"
+    end
+
+    it "generates the Sublayer Generator code and filename" do
+      VCR.use_cassette("claude/cli/generators/sublayer_generator_generator") do
+        results = generate("a sublayer generator that takes in code and converts it to the users requested programming language")
+
+        expect(results.filename).to be_a(String)
+        expect(results.filename.length).to be > 0
+        expect(results.code).to be_a(String)
+        expect(results.code.length).to be > 0
+      end
+    end
+  end
+
+  context "OpenAI" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+      Sublayer.configuration.ai_model = "gpt-4o-mini"
+    end
+
+    it "generates the Sublayer Generator code and filename" do
+      VCR.use_cassette("openai/cli/generators/sublayer_generator_generator") do
+        results = generate("a sublayer generator that takes in code and converts it to the users requested programming language")
+
+        expect(results.filename).to be_a(String)
+        expect(results.filename.length).to be > 0
+        expect(results.code).to be_a(String)
+        expect(results.code.length).to be > 0
+      end
+    end
+
+  end
+
+  context "Gemini" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+      Sublayer.configuration.ai_model = "gemini-1.5-pro-latest"
+    end
+
+    it "generates the Sublayer Generator code and filename" do
+      VCR.use_cassette("gemini/cli/generators/sublayer_generator_generator") do
+        results = generate("a sublayer generator that takes in code and converts it to the users requested programming language")
+
+        expect(results.filename).to be_a(String)
+        expect(results.filename.length).to be > 0
+        expect(results.code).to be_a(String)
+        expect(results.code.length).to be > 0
+      end
+    end
+
+  end
+end

--- a/spec/vcr_cassettes/claude/cli/generators/sublayer_generator_generator.yml
+++ b/spec/vcr_cassettes/claude/cli/generators/sublayer_generator_generator.yml
@@ -1,0 +1,136 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"model":"claude-3-haiku-20240307","max_tokens":4096,"tools":[{"name":"sublayer_generator","description":"The
+        new Sublayer generator code based on the description","input_schema":{"type":"object","properties":{"sublayer_generator":{"type":"object","description":"The
+        new Sublayer generator code based on the description","properties":{"code":{"type":"string","description":"The
+        code of the generated Sublayer generator"},"filename":{"type":"string","description":"The
+        filename of the generated Sublayer generator camel cased and with a .rb extension"}},"required":["code","filename"]}},"required":["sublayer_generator"]}}],"tool_choice":{"type":"tool","name":"sublayer_generator"},"messages":[{"role":"user","content":"    You
+        are an expert ruby programmer and and great at repurposing code examples to
+        use for new situations.\n\n    A Sublayer generator is a class that acts as
+        an abstraction for sending a request to an LLM and getting structured data
+        back.\n\n    An example Sublayer generator is:\n    <example_generator>\n    class
+        CodeFromDescriptionGenerator < Sublayer::Generators::Base\n  llm_output_adapter
+        type: :single_string,\n    name: \"generated_code\",\n    description: \"The
+        generated code in the requested language\"\n\n  def initialize(description:,
+        technologies:)\n    @description = description\n    @technologies = technologies\n  end\n\n  def
+        generate\n    super\n  end\n\n  def prompt\n    <<-PROMPT\n        You are
+        an expert programmer in #{@technologies.join(\", \")}.\n\n        You are
+        tasked with writing code using the following technologies: #{@technologies.join(\",
+        \")}.\n\n        The description of the task is #{@description}\n\n        Take
+        a deep breath and think step by step before you start coding.\n    PROMPT\n  end\nend\n\n    </example_generator>\n\n    And
+        it is the generator we''re currently using for taking in a description from
+        a user and generating a new Sublayer generator.\n\n    All Sublayer::Generators
+        inherit from Sublayer::Generators::Base and have a generate method that simply
+        calls super for the user to use and modify for their uses.\n\n    the llm_output_adapter
+        directive is used to instruct the LLM on what structure of output to generate.
+        In the example we''re using type: :single_string which takes a name and description
+        as arguments.\n\n    the other available options and their example usage is:\n    llm_output_adapter
+        type: :list_of_strings,\n      name: \"suggestions\",\n      description:
+        \"List of keyword suggestions\"\n\n    llm_output_adapter type: :single_integer,\n      name:
+        \"four_digit_passcode\",\n      description: \"an uncommon and difficult to
+        guess four digit passcode\"\n\n    llm_output_adapter type: :list_of_named_strings,\n      name:
+        \"review_summaries\",\n      description: \"List of movie reviews\",\n      item_name:
+        \"review\",\n      attributes: [\n        { name: \"movie_title\", description:
+        \"The title of the movie\" },\n        { name: \"reviewer_name\", description:
+        \"The name of the reviewer\" },\n        { name: \"rating\", description:
+        \"The rating given by the reviewer (out of 5 stars)\" },\n        { name:
+        \"brief_comment\", description: \"A brief summary of the movie\" }\n      ]\n\n    llm_output_adapter
+        type: :named_strings,\n      name: \"product_description\",\n      description:
+        \"Generate product descriptions\",\n      attributes: [\n        { name: \"short_description\",
+        description: \"A brief one-sentence description of the product\" },\n        {
+        name: \"long_description\", description: \"A detailed paragraph describing
+        the product\" },\n        { name: \"key_features\", description: \"A comma-separated
+        list of key product features\" },\n        { name: \"target_audience\", description:
+        \"A brief description of the target audience for this product\" }\n      ]\n\n    #
+        Where :available_routes is a method that returns an array of available routes\n    llm_output_adapter
+        type: :string_selection_from_list,\n      name: \"route\",\n      description:
+        \"A route selected from the list\",\n      options: :available_routes\n\n    #
+        Where @sentiment_options is an array of sentiment values passed in to the
+        initializer\n    llm_output_adapter type: :string_selection_from_list,\n      name:
+        \"sentiment_value\",\n      description: \"A sentiment value from the list\",\n      options:
+        -> { @sentiment_options }\n\n    Besides that, a Sublayer::Generator also
+        has a prompt method that describes the task to the LLM and provides any necessary
+        context for the generation which\n    is either passed in through the initializer
+        or accessed in the prompt itself.\n\n    You have a description provided by
+        the user to generate a new sublayer generator.\n\n    You are tasked with
+        creating a new sublayer generator according to the given description.\n\n    Consider
+        the details and requirements mentioned in the description to create the appropriate
+        Sublayer::Generator.\n    <users_description>\n    a sublayer generator that
+        takes in code and converts it to the users requested programming language\n    </users_description>\n\n    Take
+        a deep breath and reflect on each aspect of the description before proceeding
+        with the generation.\n"}]}'
+    headers:
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Content-Type:
+      - application/json
+      Anthropic-Beta:
+      - tools-2024-04-04
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 28 Aug 2024 21:08:41 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Requests-Limit:
+      - '1000'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '999'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2024-08-28T21:09:34Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '100000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '100000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2024-08-28T21:08:41Z'
+      Request-Id:
+      - req_01J3DTorZu8gJuxkjzpTv7Ww
+      X-Cloud-Trace-Context:
+      - fea889f4d4fd176510829627b5f0b9be
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8ba7471f5e1a7cb1-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"msg_01Ths4r5nTPZYbtEWZAP6mds","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[{"type":"tool_use","id":"toolu_01CpAGDdUnVPMVUPoqRm4BVB","name":"sublayer_generator","input":{"sublayer_generator":{"code":"class
+        CodeToLanguageGenerator < Sublayer::Generators::Base\n  llm_output_adapter
+        type: :single_string,\n    name: \"generated_code\",\n    description: \"The
+        generated code in the requested language\"\n\n  def initialize(code:, target_language:)\n    @code
+        = code\n    @target_language = target_language\n  end\n\n  def generate\n    super\n  end\n\n  def
+        prompt\n    <<-PROMPT\n    You are an expert programmer who is highly skilled
+        at translating code from one programming language to another.\n\n    You have
+        been provided the following code:\n\n    #{@code}\n\n    Please translate
+        this code to the #{@target_language} programming language, while maintaining
+        the same functionality and logic.\n\n    Take your time to carefully review
+        the code and think through the best approach for translating it before you
+        start writing the new version.\n    PROMPT\n  end\nend","filename":"code_to_language_generator.rb"}}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":1556,"output_tokens":270}}'
+  recorded_at: Wed, 28 Aug 2024 21:08:41 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/gemini/cli/generators/sublayer_generator_generator.yml
+++ b/spec/vcr_cassettes/gemini/cli/generators/sublayer_generator_generator.yml
@@ -1,0 +1,146 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent?key=<GEMINI_API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"contents":{"role":"user","parts":{"text":"    You are an expert ruby
+        programmer and and great at repurposing code examples to use for new situations.\n\n    A
+        Sublayer generator is a class that acts as an abstraction for sending a request
+        to an LLM and getting structured data back.\n\n    An example Sublayer generator
+        is:\n    <example_generator>\n    class CodeFromDescriptionGenerator < Sublayer::Generators::Base\n  llm_output_adapter
+        type: :single_string,\n    name: \"generated_code\",\n    description: \"The
+        generated code in the requested language\"\n\n  def initialize(description:,
+        technologies:)\n    @description = description\n    @technologies = technologies\n  end\n\n  def
+        generate\n    super\n  end\n\n  def prompt\n    <<-PROMPT\n        You are
+        an expert programmer in #{@technologies.join(\", \")}.\n\n        You are
+        tasked with writing code using the following technologies: #{@technologies.join(\",
+        \")}.\n\n        The description of the task is #{@description}\n\n        Take
+        a deep breath and think step by step before you start coding.\n    PROMPT\n  end\nend\n\n    </example_generator>\n\n    And
+        it is the generator we''re currently using for taking in a description from
+        a user and generating a new Sublayer generator.\n\n    All Sublayer::Generators
+        inherit from Sublayer::Generators::Base and have a generate method that simply
+        calls super for the user to use and modify for their uses.\n\n    the llm_output_adapter
+        directive is used to instruct the LLM on what structure of output to generate.
+        In the example we''re using type: :single_string which takes a name and description
+        as arguments.\n\n    the other available options and their example usage is:\n    llm_output_adapter
+        type: :list_of_strings,\n      name: \"suggestions\",\n      description:
+        \"List of keyword suggestions\"\n\n    llm_output_adapter type: :single_integer,\n      name:
+        \"four_digit_passcode\",\n      description: \"an uncommon and difficult to
+        guess four digit passcode\"\n\n    llm_output_adapter type: :list_of_named_strings,\n      name:
+        \"review_summaries\",\n      description: \"List of movie reviews\",\n      item_name:
+        \"review\",\n      attributes: [\n        { name: \"movie_title\", description:
+        \"The title of the movie\" },\n        { name: \"reviewer_name\", description:
+        \"The name of the reviewer\" },\n        { name: \"rating\", description:
+        \"The rating given by the reviewer (out of 5 stars)\" },\n        { name:
+        \"brief_comment\", description: \"A brief summary of the movie\" }\n      ]\n\n    llm_output_adapter
+        type: :named_strings,\n      name: \"product_description\",\n      description:
+        \"Generate product descriptions\",\n      attributes: [\n        { name: \"short_description\",
+        description: \"A brief one-sentence description of the product\" },\n        {
+        name: \"long_description\", description: \"A detailed paragraph describing
+        the product\" },\n        { name: \"key_features\", description: \"A comma-separated
+        list of key product features\" },\n        { name: \"target_audience\", description:
+        \"A brief description of the target audience for this product\" }\n      ]\n\n    #
+        Where :available_routes is a method that returns an array of available routes\n    llm_output_adapter
+        type: :string_selection_from_list,\n      name: \"route\",\n      description:
+        \"A route selected from the list\",\n      options: :available_routes\n\n    #
+        Where @sentiment_options is an array of sentiment values passed in to the
+        initializer\n    llm_output_adapter type: :string_selection_from_list,\n      name:
+        \"sentiment_value\",\n      description: \"A sentiment value from the list\",\n      options:
+        -> { @sentiment_options }\n\n    Besides that, a Sublayer::Generator also
+        has a prompt method that describes the task to the LLM and provides any necessary
+        context for the generation which\n    is either passed in through the initializer
+        or accessed in the prompt itself.\n\n    You have a description provided by
+        the user to generate a new sublayer generator.\n\n    You are tasked with
+        creating a new sublayer generator according to the given description.\n\n    Consider
+        the details and requirements mentioned in the description to create the appropriate
+        Sublayer::Generator.\n    <users_description>\n    a sublayer generator that
+        takes in code and converts it to the users requested programming language\n    </users_description>\n\n    Take
+        a deep breath and reflect on each aspect of the description before proceeding
+        with the generation.\n"}},"generationConfig":{"responseMimeType":"application/json","responseSchema":{"type":"OBJECT","properties":{"sublayer_generator":{"type":"object","description":"The
+        new Sublayer generator code based on the description","properties":{"code":{"type":"string","description":"The
+        code of the generated Sublayer generator"},"filename":{"type":"string","description":"The
+        filename of the generated Sublayer generator camel cased and with a .rb extension"}},"required":["code","filename"]}},"required":["sublayer_generator"]}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Wed, 28 Aug 2024 21:09:38 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - gfet4t7; dur=12293
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "candidates": [
+            {
+              "content": {
+                "parts": [
+                  {
+                    "text": "{\n\"sublayer_generator\": {\n\"code\": \"class CodeLanguageConverter \u003c Sublayer::Generators::Base\\n  llm_output_adapter type: :single_string,\\n    name: \\\"converted_code\\\",\\n    description: \\\"The code converted to the requested language\\\"\\n\\n  def initialize(code:, target_language:)\\n    @code = code\\n    @target_language = target_language\\n  end\\n\\n  def generate\\n    super\\n  end\\n\\n  def prompt\\n    \u003c\u003c-PROMPT\\n        You are an expert programmer.\\n\\n        You are tasked with converting code from one language to another.\\n\\n        The code to convert is: #{@code}\\n\\n        The target language is: #{@target_language}\\n\\n        Take a deep breath and think step by step before you start coding.\\n    PROMPT\\n  end\\nend\",\n\"filename\": \"CodeLanguageConverter.rb\"\n}\n} "
+                  }
+                ],
+                "role": "model"
+              },
+              "finishReason": "STOP",
+              "index": 0,
+              "safetyRatings": [
+                {
+                  "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                  "probability": "NEGLIGIBLE"
+                },
+                {
+                  "category": "HARM_CATEGORY_HATE_SPEECH",
+                  "probability": "NEGLIGIBLE"
+                },
+                {
+                  "category": "HARM_CATEGORY_HARASSMENT",
+                  "probability": "NEGLIGIBLE"
+                },
+                {
+                  "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                  "probability": "NEGLIGIBLE"
+                }
+              ]
+            }
+          ],
+          "usageMetadata": {
+            "promptTokenCount": 1008,
+            "candidatesTokenCount": 223,
+            "totalTokenCount": 1231
+          }
+        }
+  recorded_at: Wed, 28 Aug 2024 21:09:38 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/openai/cli/generators/sublayer_generator_generator.yml
+++ b/spec/vcr_cassettes/openai/cli/generators/sublayer_generator_generator.yml
@@ -1,0 +1,169 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"    You
+        are an expert ruby programmer and and great at repurposing code examples to
+        use for new situations.\n\n    A Sublayer generator is a class that acts as
+        an abstraction for sending a request to an LLM and getting structured data
+        back.\n\n    An example Sublayer generator is:\n    <example_generator>\n    class
+        CodeFromDescriptionGenerator < Sublayer::Generators::Base\n  llm_output_adapter
+        type: :single_string,\n    name: \"generated_code\",\n    description: \"The
+        generated code in the requested language\"\n\n  def initialize(description:,
+        technologies:)\n    @description = description\n    @technologies = technologies\n  end\n\n  def
+        generate\n    super\n  end\n\n  def prompt\n    <<-PROMPT\n        You are
+        an expert programmer in #{@technologies.join(\", \")}.\n\n        You are
+        tasked with writing code using the following technologies: #{@technologies.join(\",
+        \")}.\n\n        The description of the task is #{@description}\n\n        Take
+        a deep breath and think step by step before you start coding.\n    PROMPT\n  end\nend\n\n    </example_generator>\n\n    And
+        it is the generator we''re currently using for taking in a description from
+        a user and generating a new Sublayer generator.\n\n    All Sublayer::Generators
+        inherit from Sublayer::Generators::Base and have a generate method that simply
+        calls super for the user to use and modify for their uses.\n\n    the llm_output_adapter
+        directive is used to instruct the LLM on what structure of output to generate.
+        In the example we''re using type: :single_string which takes a name and description
+        as arguments.\n\n    the other available options and their example usage is:\n    llm_output_adapter
+        type: :list_of_strings,\n      name: \"suggestions\",\n      description:
+        \"List of keyword suggestions\"\n\n    llm_output_adapter type: :single_integer,\n      name:
+        \"four_digit_passcode\",\n      description: \"an uncommon and difficult to
+        guess four digit passcode\"\n\n    llm_output_adapter type: :list_of_named_strings,\n      name:
+        \"review_summaries\",\n      description: \"List of movie reviews\",\n      item_name:
+        \"review\",\n      attributes: [\n        { name: \"movie_title\", description:
+        \"The title of the movie\" },\n        { name: \"reviewer_name\", description:
+        \"The name of the reviewer\" },\n        { name: \"rating\", description:
+        \"The rating given by the reviewer (out of 5 stars)\" },\n        { name:
+        \"brief_comment\", description: \"A brief summary of the movie\" }\n      ]\n\n    llm_output_adapter
+        type: :named_strings,\n      name: \"product_description\",\n      description:
+        \"Generate product descriptions\",\n      attributes: [\n        { name: \"short_description\",
+        description: \"A brief one-sentence description of the product\" },\n        {
+        name: \"long_description\", description: \"A detailed paragraph describing
+        the product\" },\n        { name: \"key_features\", description: \"A comma-separated
+        list of key product features\" },\n        { name: \"target_audience\", description:
+        \"A brief description of the target audience for this product\" }\n      ]\n\n    #
+        Where :available_routes is a method that returns an array of available routes\n    llm_output_adapter
+        type: :string_selection_from_list,\n      name: \"route\",\n      description:
+        \"A route selected from the list\",\n      options: :available_routes\n\n    #
+        Where @sentiment_options is an array of sentiment values passed in to the
+        initializer\n    llm_output_adapter type: :string_selection_from_list,\n      name:
+        \"sentiment_value\",\n      description: \"A sentiment value from the list\",\n      options:
+        -> { @sentiment_options }\n\n    Besides that, a Sublayer::Generator also
+        has a prompt method that describes the task to the LLM and provides any necessary
+        context for the generation which\n    is either passed in through the initializer
+        or accessed in the prompt itself.\n\n    You have a description provided by
+        the user to generate a new sublayer generator.\n\n    You are tasked with
+        creating a new sublayer generator according to the given description.\n\n    Consider
+        the details and requirements mentioned in the description to create the appropriate
+        Sublayer::Generator.\n    <users_description>\n    a sublayer generator that
+        takes in code and converts it to the users requested programming language\n    </users_description>\n\n    Take
+        a deep breath and reflect on each aspect of the description before proceeding
+        with the generation.\n"}],"tool_choice":{"type":"function","function":{"name":"sublayer_generator"}},"tools":[{"type":"function","function":{"name":"sublayer_generator","description":"The
+        new Sublayer generator code based on the description","parameters":{"type":"object","properties":{"sublayer_generator":{"type":"object","description":"The
+        new Sublayer generator code based on the description","properties":{"code":{"type":"string","description":"The
+        code of the generated Sublayer generator"},"filename":{"type":"string","description":"The
+        filename of the generated Sublayer generator camel cased and with a .rb extension"}},"required":["code","filename"]}}},"required":["sublayer_generator"]}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 28 Aug 2024 21:08:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - sublayer
+      Openai-Processing-Ms:
+      - '1995'
+      Openai-Version:
+      - '2020-10-01'
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '10000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '9998909'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 6ms
+      X-Request-Id:
+      - req_5662e7cab2052515585c718728c2189e
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=yMnTGgs9wUFTS9Q3kdNbWevMHqG.5F.unxP9AhH8Vf4-1724879324-1.0.1.1-.bSWXI4E4px1rJw_CHxUhpzY4s823rVNypPzj4UNWaMoSm.7wecHLlp7ccI_gGC7jJTAfb.vDDwmPGPtcVBr.Q;
+        path=/; expires=Wed, 28-Aug-24 21:38:44 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=GWDhoOKUEGq4Tcr1U9FWC7XPORqCfHzbYOlKwIRfUHc-1724879324119-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8ba747314db11927-EWR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-A1KCAAhfBSxAG9DfuGQYDwPBcNQm4",
+          "object": "chat.completion",
+          "created": 1724879322,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                  {
+                    "id": "call_ecFR7eEEPJFEJ8M6FqaCyEVm",
+                    "type": "function",
+                    "function": {
+                      "name": "sublayer_generator",
+                      "arguments": "{\"sublayer_generator\":{\"code\":\"class CodeConverterGenerator < Sublayer::Generators::Base\\n  llm_output_adapter type: :single_string,\\n    name: \\\"converted_code\\\",\\n    description: \\\"The converted code in the requested programming language\\\"\\n\\n  def initialize(input_code:, target_language:)\\n    @input_code = input_code\\n    @target_language = target_language\\n  end\\n\\n  def generate\\n    super\\n  end\\n\\n  def prompt\\n    <<-PROMPT\\n        You are an expert programmer in various programming languages.\\n\\n        You are tasked with converting the following code to #{@target_language}:\\n        #{@input_code}\\n\\n        Please ensure that the conversion is syntactically correct and follows best practices for #{@target_language}.\\n    PROMPT\\n  end\\nend\",\"filename\":\"codeConverterGenerator.rb\"}}"
+                    }
+                  }
+                ],
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 1012,
+            "completion_tokens": 181,
+            "total_tokens": 1193
+          },
+          "system_fingerprint": "fp_f33667828e"
+        }
+  recorded_at: Wed, 28 Aug 2024 21:08:44 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
New CLI command coming!

This new command `sublayer generate generator` drops you into a walkthrough for generating a new sublayer generator for your project.

Seeing a longer prompt like this definitely makes me think we need a better abstraction for prompts - this could probably be a good place to look at and experiment with for #75 I think. There are some clear sections that I'd like to break out into methods to build the prompt, a mix of background information, few shot (1 for now) examples, and instructions. 

I also had an issue where I was using the same heredoc delimiter in the example and in the code so it blew up when I tried to just inline everything. Gotta be a better way to handle this.

Also ran into an issue trying to integration test this command as running the CLI on a separate thread wouldn't allow VCR to hook into and record the requests. Would love a better solution there to actually testing these commands. Probably need to come up with a mock provider for things like this.

Anywho, this sets the stage pretty well for doing the same thing with Agents and Actions which should come through a lot quicker and be ready for a release very shortly!

