### PR TITLE
Add the sublayer generate agent command

### DIFF
--- a/lib/sublayer/cli/commands/agent.rb
+++ b/lib/sublayer/cli/commands/agent.rb
@@ -1,0 +1,79 @@
+require_relative "./generators/sublayer_agent_generator"
+
+module Sublayer
+  module Commands
+    class Agent < Thor::Group
+      include Thor::Actions
+
+      class_option :description, type: :string, desc: "Description of the agent you want to generate", aliases: :d
+      class_option :provider, type: :string, desc: "AI provider (OpenAI, Claude, or Gemini)", aliases: :p
+      class_option :model, type: :string, desc: "AI model name to use (e.g. gpt-4o, claude-3-haiku-20240307, gemini-1.5-flash-latest)", aliases: :m
+
+      def confirm_usage_of_ai_api
+        puts "You are about to generate a new agent that uses an AI API to generate content."
+        puts "Please ensure you have the necessary API keys and that you are aware of the costs associated with using the API."
+        exit unless yes?("Do you want to continue?")
+      end
+
+      def determine_available_providers
+        @available_providers = []
+
+        @available_providers << "OpenAI" if ENV["OPENAI_API_KEY"]
+        @available_providers << "Claude" if ENV["ANTHROPIC_API_KEY"]
+        @available_providers << "Gemini" if ENV["GEMINI_API_KEY"]
+      end
+
+      def ask_for_agent_details
+        @ai_provider = options[:provider] || ask("Select an AI provider:", default: "OpenAI", limited_to: @available_providers)
+        @ai_model = options[:model] || select_ai_model
+        @description = options[:description] || ask("Enter a description for the Sublayer Agent you'd like to create:")
+        @trigger = ask("What should trigger this agent to start acting?")
+        @goal = ask("What is the agent's goal condition?")
+        @check_status = ask("How should the agent check its status toward the goal?")
+        @step = ask("How does the agent take a step toward its goal?")
+      end
+
+      def generate_agent
+        Sublayer.configuration.ai_provider = Object.const_get("Sublayer::Providers::#{@ai_provider}")
+        Sublayer.configuration.ai_model = @ai_model
+
+        say "Generating Sublayer Agent..."
+
+        @results = SublayerAgentGenerator.new(
+          description: @description,
+          trigger: @trigger_explanation,
+          goal: @goal,
+          check_status: @check_status,
+          step: @step
+        ).generate
+      end
+
+      def determine_destination_folder
+        @destination_folder = if File.directory?("./agents")
+                                "./agents"
+                              elsif Dir.glob("./lib/**/agents").any?
+                                Dir.glob("./lib/**/agents").first
+                              else
+                                "./"
+                              end
+      end
+
+      def save_agent_to_destination_folder
+        create_file File.join(@destination_folder, @results.filename), @results.code
+      end
+
+      private
+
+      def select_ai_model
+        case @ai_provider
+        when "OpenAI"
+          ask("Which OpenAI model would you like to use?", default: "gpt-4o")
+        when "Claude"
+          ask("Which Anthropic model would you like to use?", default: "claude-3-5-sonnet-20240620")
+        when "Gemini"
+          ask("Which Google model would you like to use?", default: "gemini-1.5-flash-latest")
+        end
+      end
+    end
+  end
+end

--- a/lib/sublayer/cli/commands/generate.rb
+++ b/lib/sublayer/cli/commands/generate.rb
@@ -1,9 +1,11 @@
 require_relative "./generator"
+require_relative "./agent"
 
 module Sublayer
   module Commands
     class Generate < SubCommandBase
       register(Sublayer::Commands::Generator, "generator", "generator", "Generates a new Sublayer::Generator subclass for your project")
+      register(Sublayer::Commands::Agent, "agent", "agent", "Generates a new Sublayer::Agent subclass for your project")
     end
   end
 end

--- a/lib/sublayer/cli/commands/generators/example_agent.rb
+++ b/lib/sublayer/cli/commands/generators/example_agent.rb
@@ -1,0 +1,33 @@
+class RSpecAgent < Sublayer::Agents::Base
+  def initialize(implementation_file_path:, test_file_path:)
+    @implementation_file_path = implementation_file_path
+    @test_file_path = test_file_path
+    @tests_passing = false
+  end
+
+  trigger_on_files_changed { [@implementation_file_path, @test_file_path] }
+
+  goal_condition { @tests_passing == true }
+
+  check_status do
+    stdout, stderr, status = Sublayer::Actions::RunTestCommandAction.new(
+      test_command: "rspec #{@test_file_path}"
+    ).call
+
+    @test_output = stdout
+    @tests_passing = (status.exitstatus == 0)
+  end
+
+  step do
+    modified_implementation = Sublayer::Generators::ModifiedImplementationToPassTestsGenerator.new(
+      implementation_file_contents: File.read(@implementation_file_path),
+      test_file_contents: File.read(@test_file_path),
+      test_output: @test_output
+    ).generate
+
+    Sublayer::Actions::WriteFileAction.new(
+      file_contents: modified_implementation,
+      file_path: @implementation_file_path
+    ).call
+  end
+end

--- a/lib/sublayer/cli/commands/generators/sublayer_agent_generator.rb
+++ b/lib/sublayer/cli/commands/generators/sublayer_agent_generator.rb
@@ -1,0 +1,61 @@
+class SublayerAgentGenerator < Sublayer::Generators::Base
+  llm_output_adapter type: :named_strings,
+    name: "sublayer_agent",
+    description: "The new sublayer agent based on the description and supporting information",
+    attributes: [
+      { name: "code", description: "The code of the generated Sublayer agent" },
+      { name: "filename", description: "The filename of the generated sublayer agent snake cased with a .rb extension" }
+    ]
+
+  def initialize(description:, trigger:, goal:, check_status:, step:)
+    @description = description
+    @trigger_condition = trigger
+    @goal = goal
+    @check_status = check_status
+    @step = step
+  end
+
+  def generate
+    super
+  end
+
+  def prompt
+    <<-PROMPT
+    You are an expert ruby programmer and great at repurposing code examples to use for new situations.
+
+    A Sublayer agent is a DSL for defining a feedback loop for an AI agent. The agents sit running like a daemon and are triggered to run and step toward their goal checking status along the way.
+
+    One example of a Sublayer agent is this one for doing TDD with RSpec:
+    <example_tdd_agent>
+    #{example_agent}
+    </example_tdd_agent>
+
+    Sublayer Agents take advantage of other Sublayer components to perform their tasks.
+    Sublayer::Actions are used to perform actions in the outside world, things like saving files, making external api calls, retrieving data, etc
+    Sublayer::Generators are used to make calls to LLMs based on information they receive from Sublayer::Actions or other sources and return structured data for other Sublayer::Actions to do use in the outside world
+
+    The Sublayer Agent DSL consists of 4 main parts:
+    1. trigger: What triggers the agent, currently built into the framework is the trigger_on_files_changed, but the trigger method also accepts a Sublayer::Triggers::Base subclass that defines an initialize method and a setup method that takes an agent as an argument
+                The setup method then calls activate(agent) when the trigger condition is met
+    2. goal: What the agent is trying to achieve, this is a block that returns a boolean
+    3. check_status: A method that checks the status of the agent on its way toward the goal. Usually you update the goal condition here or can perform any Sublayer::Actions to examine the state of the outside world
+    4. step: A method that encapsulates the way the agent should work toward the goal. Sublayer::Actions and Sublayer::Generators are used heavily here.
+
+    Your goal is to rely on the above information about how Sublayer Agents work to generate a new Sublayer agent based on the following information:
+
+    Agent description: #{@description}
+    Trigger condition: #{@trigger}
+    Goal condition: #{@goal}
+    Status check method: #{@check_status}
+    Step action method: #{@step}
+
+    You can assume that any Sublayer::Actions or Sublayer::Generators you need are available to you in the Sublayer framework
+
+    Take a deep breath and think step by step before coding. You can do this!
+    PROMPT
+  end
+
+  def example_agent
+    File.read(File.join(__dir__, "example_agent.rb"))
+  end
+end

--- a/lib/sublayer/cli/commands/generators/sublayer_generator_generator.rb
+++ b/lib/sublayer/cli/commands/generators/sublayer_generator_generator.rb
@@ -4,7 +4,7 @@ class SublayerGeneratorGenerator < Sublayer::Generators::Base
     description: "The new Sublayer generator code based on the description",
     attributes: [
       { name: "code", description: "The code of the generated Sublayer generator" },
-      { name: "filename", description: "The filename of the generated Sublayer generator camel cased and with a .rb extension" }
+      { name: "filename", description: "The filename of the generated Sublayer generator snake cased and with a .rb extension" }
     ]
 
   def initialize(description:)

--- a/spec/cli/generators/agent_generator_spec.rb
+++ b/spec/cli/generators/agent_generator_spec.rb
@@ -1,0 +1,90 @@
+require "spec_helper"
+
+require_relative "../../../lib/sublayer/cli/commands/generators/sublayer_agent_generator"
+
+RSpec.describe SublayerAgentGenerator do
+  def generate(description, trigger, goal, check_status, step)
+    described_class.new(
+      description: description,
+      trigger: trigger,
+      goal: goal,
+      check_status: check_status,
+      step: step
+    ).generate
+  end
+
+  context "Claude" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+      Sublayer.configuration.ai_model = "claude-3-haiku-20240307"
+    end
+
+    it "generates the sublayer agent code and filename" do
+      VCR.use_cassette("claude/cli/generators/sublayer_agent_generator") do
+        results = generate(
+          "a sublayer agent that monitors a transcription folder and updates a notion crm with information from the latest transcriptions",
+          "new files are added to a transcription folder",
+          "all the transcription files in the folder have been processed",
+          "see if there are any files in the transcription folder that havent been procesed",
+          "take an unprocessed transcription file, generate a summary, and any followups, and update the notion crm with the information"
+        )
+
+        binding.pry
+        expect(results.filename).to be_a(String)
+        expect(results.filename.length).to be > 0
+        expect(results.code).to be_a(String)
+        expect(results.code.length).to be > 0
+      end
+    end
+  end
+
+  context "OpenAI" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+      Sublayer.configuration.ai_model = "gpt-4o-mini"
+    end
+
+    it "generates the sublayer agent code and filename" do
+      VCR.use_cassette("openai/cli/generators/sublayer_agent_generator") do
+        results = generate(
+          "a sublayer agent that monitors a transcription folder and updates a notion crm with information from the latest transcriptions",
+          "new files are added to a transcription folder",
+          "all the transcription files in the folder have been processed",
+          "see if there are any files in the transcription folder that havent been procesed",
+          "take an unprocessed transcription file, generate a summary, and any followups, and update the notion crm with the information"
+        )
+
+        binding.pry
+        expect(results.filename).to be_a(String)
+        expect(results.filename.length).to be > 0
+        expect(results.code).to be_a(String)
+        expect(results.code.length).to be > 0
+      end
+    end
+  end
+
+  context "Gemini" do
+    before do
+      Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+      Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
+    end
+
+    it "generates the sublayer agent code and filename" do
+      VCR.use_cassette("gemini/cli/generators/sublayer_agent_generator") do
+        results = generate(
+          "a sublayer agent that monitors a transcription folder and updates a notion crm with information from the latest transcriptions",
+          "new files are added to a transcription folder",
+          "all the transcription files in the folder have been processed",
+          "see if there are any files in the transcription folder that havent been procesed",
+          "take an unprocessed transcription file, generate a summary, and any followups, and update the notion crm with the information"
+        )
+
+        binding.pry
+        expect(results.filename).to be_a(String)
+        expect(results.filename.length).to be > 0
+        expect(results.code).to be_a(String)
+        expect(results.code.length).to be > 0
+      end
+    end
+  end
+end

--- a/spec/cli/generators/agent_generator_spec.rb
+++ b/spec/cli/generators/agent_generator_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe SublayerAgentGenerator do
           "take an unprocessed transcription file, generate a summary, and any followups, and update the notion crm with the information"
         )
 
-        binding.pry
         expect(results.filename).to be_a(String)
         expect(results.filename.length).to be > 0
         expect(results.code).to be_a(String)
@@ -54,7 +53,6 @@ RSpec.describe SublayerAgentGenerator do
           "take an unprocessed transcription file, generate a summary, and any followups, and update the notion crm with the information"
         )
 
-        binding.pry
         expect(results.filename).to be_a(String)
         expect(results.filename.length).to be > 0
         expect(results.code).to be_a(String)
@@ -79,7 +77,6 @@ RSpec.describe SublayerAgentGenerator do
           "take an unprocessed transcription file, generate a summary, and any followups, and update the notion crm with the information"
         )
 
-        binding.pry
         expect(results.filename).to be_a(String)
         expect(results.filename.length).to be > 0
         expect(results.code).to be_a(String)

--- a/spec/vcr_cassettes/claude/cli/generators/sublayer_agent_generator.yml
+++ b/spec/vcr_cassettes/claude/cli/generators/sublayer_agent_generator.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"model":"claude-3-haiku-20240307","max_tokens":4096,"tools":[{"name":"sublayer_agent","description":"The
+        new sublayer agent based on the description and supporting information","input_schema":{"type":"object","properties":{"sublayer_agent":{"type":"object","description":"The
+        new sublayer agent based on the description and supporting information","properties":{"code":{"type":"string","description":"The
+        code of the generated Sublayer agent"},"filename":{"type":"string","description":"The
+        filename of the generated sublayer agent snake cased with a .rb extension"}},"required":["code","filename"]}},"required":["sublayer_agent"]}}],"tool_choice":{"type":"tool","name":"sublayer_agent"},"messages":[{"role":"user","content":"    You
+        are an expert ruby programmer and great at repurposing code examples to use
+        for new situations.\n\n    A Sublayer agent is a DSL for defining a feedback
+        loop for an AI agent. The agents sit running like a daemon and are triggered
+        to run and step toward their goal checking status along the way.\n\n    One
+        example of a Sublayer agent is this one for doing TDD with RSpec:\n    <example_tdd_agent>\n    class
+        RSpecAgent < Sublayer::Agents::Base\n  def initialize(implementation_file_path:,
+        test_file_path:)\n    @implementation_file_path = implementation_file_path\n    @test_file_path
+        = test_file_path\n    @tests_passing = false\n  end\n\n  trigger_on_files_changed
+        { [@implementation_file_path, @test_file_path] }\n\n  goal_condition { @tests_passing
+        == true }\n\n  check_status do\n    stdout, stderr, status = Sublayer::Actions::RunTestCommandAction.new(\n      test_command:
+        \"rspec #{@test_file_path}\"\n    ).call\n\n    @test_output = stdout\n    @tests_passing
+        = (status.exitstatus == 0)\n  end\n\n  step do\n    modified_implementation
+        = Sublayer::Generators::ModifiedImplementationToPassTestsGenerator.new(\n      implementation_file_contents:
+        File.read(@implementation_file_path),\n      test_file_contents: File.read(@test_file_path),\n      test_output:
+        @test_output\n    ).generate\n\n    Sublayer::Actions::WriteFileAction.new(\n      file_contents:
+        modified_implementation,\n      file_path: @implementation_file_path\n    ).call\n  end\nend\n\n    </example_tdd_agent>\n\n    Sublayer
+        Agents take advantage of other Sublayer components to perform their tasks.\n    Sublayer::Actions
+        are used to perform actions in the outside world, things like saving files,
+        making external api calls, retrieving data, etc\n    Sublayer::Generators
+        are used to make calls to LLMs based on information they receive from Sublayer::Actions
+        or other sources and return structured data for other Sublayer::Actions to
+        do use in the outside world\n\n    The Sublayer Agent DSL consists of 4 main
+        parts:\n    1. trigger: What triggers the agent, currently built into the
+        framework is the trigger_on_files_changed, but the trigger method also accepts
+        a Sublayer::Triggers::Base subclass that defines an initialize method and
+        a setup method that takes an agent as an argument\n                The setup
+        method then calls activate(agent) when the trigger condition is met\n    2.
+        goal: What the agent is trying to achieve, this is a block that returns a
+        boolean\n    3. check_status: A method that checks the status of the agent
+        on its way toward the goal. Usually you update the goal condition here or
+        can perform any Sublayer::Actions to examine the state of the outside world\n    4.
+        step: A method that encapsulates the way the agent should work toward the
+        goal. Sublayer::Actions and Sublayer::Generators are used heavily here.\n\n    Your
+        goal is to rely on the above information about how Sublayer Agents work to
+        generate a new Sublayer agent based on the following information:\n\n    Agent
+        description: a sublayer agent that monitors a transcription folder and updates
+        a notion crm with information from the latest transcriptions\n    Trigger
+        condition: \n    Goal condition: all the transcription files in the folder
+        have been processed\n    Status check method: see if there are any files in
+        the transcription folder that havent been procesed\n    Step action method:
+        take an unprocessed transcription file, generate a summary, and any followups,
+        and update the notion crm with the information\n\n    You can assume that
+        any Sublayer::Actions or Sublayer::Generators you need are available to you
+        in the Sublayer framework\n\n    Take a deep breath and think step by step
+        before coding. You can do this!\n"}]}'
+    headers:
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Content-Type:
+      - application/json
+      Anthropic-Beta:
+      - tools-2024-04-04
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Aug 2024 02:11:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Requests-Limit:
+      - '1000'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '999'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2024-08-29T02:11:34Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '100000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '100000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2024-08-29T02:11:03Z'
+      Request-Id:
+      - req_01N7ymBVSiTzQ8qeTn3mFzKM
+      X-Cloud-Trace-Context:
+      - 06267ca62bdb48515e82acfd999ed731
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8ba90209dd1c422e-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"msg_01GkpWnzisWcJV7gnap1Znnv","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[{"type":"tool_use","id":"toolu_01QMtrT5XVQphUuasMzW22Dy","name":"sublayer_agent","input":{"sublayer_agent":{"code":"class
+        TranscriptionAgent < Sublayer::Agents::Base\n  def initialize(transcription_folder_path:,
+        notion_crm_integration:)\n    @transcription_folder_path = transcription_folder_path\n    @notion_crm_integration
+        = notion_crm_integration\n    @unprocessed_files = []\n  end\n\n  trigger_on_files_changed
+        { [@transcription_folder_path] }\n\n  goal_condition { @unprocessed_files.empty?
+        }\n\n  check_status do\n    @unprocessed_files = Dir.glob(File.join(@transcription_folder_path,
+        ''*'')).reject do |file|\n      # Check if file has already been processed\n      @notion_crm_integration.file_processed?(file)\n    end\n  end\n\n  step
+        do\n    unprocessed_file = @unprocessed_files.shift\n    summary, followups
+        = Sublayer::Generators::TranscriptionSummaryGenerator.new(\n      transcription_file_path:
+        unprocessed_file\n    ).generate\n    @notion_crm_integration.update_with_transcription(unprocessed_file,
+        summary, followups)\n  end\nend","filename":"transcription_agent.rb"}}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":1430,"output_tokens":340}}'
+  recorded_at: Thu, 29 Aug 2024 02:11:03 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/gemini/cli/generators/sublayer_agent_generator.yml
+++ b/spec/vcr_cassettes/gemini/cli/generators/sublayer_agent_generator.yml
@@ -1,0 +1,138 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=<GEMINI_API_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"contents":{"role":"user","parts":{"text":"    You are an expert ruby
+        programmer and great at repurposing code examples to use for new situations.\n\n    A
+        Sublayer agent is a DSL for defining a feedback loop for an AI agent. The
+        agents sit running like a daemon and are triggered to run and step toward
+        their goal checking status along the way.\n\n    One example of a Sublayer
+        agent is this one for doing TDD with RSpec:\n    <example_tdd_agent>\n    class
+        RSpecAgent < Sublayer::Agents::Base\n  def initialize(implementation_file_path:,
+        test_file_path:)\n    @implementation_file_path = implementation_file_path\n    @test_file_path
+        = test_file_path\n    @tests_passing = false\n  end\n\n  trigger_on_files_changed
+        { [@implementation_file_path, @test_file_path] }\n\n  goal_condition { @tests_passing
+        == true }\n\n  check_status do\n    stdout, stderr, status = Sublayer::Actions::RunTestCommandAction.new(\n      test_command:
+        \"rspec #{@test_file_path}\"\n    ).call\n\n    @test_output = stdout\n    @tests_passing
+        = (status.exitstatus == 0)\n  end\n\n  step do\n    modified_implementation
+        = Sublayer::Generators::ModifiedImplementationToPassTestsGenerator.new(\n      implementation_file_contents:
+        File.read(@implementation_file_path),\n      test_file_contents: File.read(@test_file_path),\n      test_output:
+        @test_output\n    ).generate\n\n    Sublayer::Actions::WriteFileAction.new(\n      file_contents:
+        modified_implementation,\n      file_path: @implementation_file_path\n    ).call\n  end\nend\n\n    </example_tdd_agent>\n\n    Sublayer
+        Agents take advantage of other Sublayer components to perform their tasks.\n    Sublayer::Actions
+        are used to perform actions in the outside world, things like saving files,
+        making external api calls, retrieving data, etc\n    Sublayer::Generators
+        are used to make calls to LLMs based on information they receive from Sublayer::Actions
+        or other sources and return structured data for other Sublayer::Actions to
+        do use in the outside world\n\n    The Sublayer Agent DSL consists of 4 main
+        parts:\n    1. trigger: What triggers the agent, currently built into the
+        framework is the trigger_on_files_changed, but the trigger method also accepts
+        a Sublayer::Triggers::Base subclass that defines an initialize method and
+        a setup method that takes an agent as an argument\n                The setup
+        method then calls activate(agent) when the trigger condition is met\n    2.
+        goal: What the agent is trying to achieve, this is a block that returns a
+        boolean\n    3. check_status: A method that checks the status of the agent
+        on its way toward the goal. Usually you update the goal condition here or
+        can perform any Sublayer::Actions to examine the state of the outside world\n    4.
+        step: A method that encapsulates the way the agent should work toward the
+        goal. Sublayer::Actions and Sublayer::Generators are used heavily here.\n\n    Your
+        goal is to rely on the above information about how Sublayer Agents work to
+        generate a new Sublayer agent based on the following information:\n\n    Agent
+        description: a sublayer agent that monitors a transcription folder and updates
+        a notion crm with information from the latest transcriptions\n    Trigger
+        condition: \n    Goal condition: all the transcription files in the folder
+        have been processed\n    Status check method: see if there are any files in
+        the transcription folder that havent been procesed\n    Step action method:
+        take an unprocessed transcription file, generate a summary, and any followups,
+        and update the notion crm with the information\n\n    You can assume that
+        any Sublayer::Actions or Sublayer::Generators you need are available to you
+        in the Sublayer framework\n\n    Take a deep breath and think step by step
+        before coding. You can do this!\n"}},"generationConfig":{"responseMimeType":"application/json","responseSchema":{"type":"OBJECT","properties":{"sublayer_agent":{"type":"object","description":"The
+        new sublayer agent based on the description and supporting information","properties":{"code":{"type":"string","description":"The
+        code of the generated Sublayer agent"},"filename":{"type":"string","description":"The
+        filename of the generated sublayer agent snake cased with a .rb extension"}},"required":["code","filename"]}},"required":["sublayer_agent"]}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Thu, 29 Aug 2024 02:11:00 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - gfet4t7; dur=2586
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "candidates": [
+            {
+              "content": {
+                "parts": [
+                  {
+                    "text": "{\"sublayer_agent\": {\"code\": \"class NotionCrmTranscriptionAgent \u003c Sublayer::Agents::Base\\n  def initialize(transcription_folder_path:, notion_crm_page_id:)\\n    @transcription_folder_path = transcription_folder_path\\n    @notion_crm_page_id = notion_crm_page_id\\n    @all_transcriptions_processed = false\\n  end\\n\\n  trigger_on_files_changed { [@transcription_folder_path] }\\n\\n  goal_condition { @all_transcriptions_processed == true }\\n\\n  check_status do\\n    unprocessed_files = Dir.glob(File.join(@transcription_folder_path, '*.txt')).reject { |file| File.basename(file).start_with?('processed_') }\\n    @all_transcriptions_processed = unprocessed_files.empty?\\n  end\\n\\n  step do\\n    unprocessed_files.each do |file|\\n      transcription_content = File.read(file)\\n\\n      summary, followups = Sublayer::Generators::TranscriptionSummarizerGenerator.new(\\n        transcription_content: transcription_content\\n      ).generate\\n\\n      Sublayer::Actions::UpdateNotionCrmAction.new(\\n        page_id: @notion_crm_page_id,\\n        summary: summary,\\n        followups: followups\\n      ).call\\n\\n      File.rename(file, File.join(File.dirname(file), 'processed_' + File.basename(file)))\\n    end\\n  end\\nend\", \"filename\": \"notion_crm_transcription_agent.rb\"}}\n"
+                  }
+                ],
+                "role": "model"
+              },
+              "finishReason": "STOP",
+              "index": 0,
+              "safetyRatings": [
+                {
+                  "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                  "probability": "NEGLIGIBLE"
+                },
+                {
+                  "category": "HARM_CATEGORY_HATE_SPEECH",
+                  "probability": "NEGLIGIBLE"
+                },
+                {
+                  "category": "HARM_CATEGORY_HARASSMENT",
+                  "probability": "NEGLIGIBLE"
+                },
+                {
+                  "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                  "probability": "NEGLIGIBLE"
+                }
+              ]
+            }
+          ],
+          "usageMetadata": {
+            "promptTokenCount": 858,
+            "candidatesTokenCount": 382,
+            "totalTokenCount": 1240
+          }
+        }
+  recorded_at: Thu, 29 Aug 2024 02:11:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/openai/cli/generators/sublayer_agent_generator.yml
+++ b/spec/vcr_cassettes/openai/cli/generators/sublayer_agent_generator.yml
@@ -1,0 +1,160 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"    You
+        are an expert ruby programmer and great at repurposing code examples to use
+        for new situations.\n\n    A Sublayer agent is a DSL for defining a feedback
+        loop for an AI agent. The agents sit running like a daemon and are triggered
+        to run and step toward their goal checking status along the way.\n\n    One
+        example of a Sublayer agent is this one for doing TDD with RSpec:\n    <example_tdd_agent>\n    class
+        RSpecAgent < Sublayer::Agents::Base\n  def initialize(implementation_file_path:,
+        test_file_path:)\n    @implementation_file_path = implementation_file_path\n    @test_file_path
+        = test_file_path\n    @tests_passing = false\n  end\n\n  trigger_on_files_changed
+        { [@implementation_file_path, @test_file_path] }\n\n  goal_condition { @tests_passing
+        == true }\n\n  check_status do\n    stdout, stderr, status = Sublayer::Actions::RunTestCommandAction.new(\n      test_command:
+        \"rspec #{@test_file_path}\"\n    ).call\n\n    @test_output = stdout\n    @tests_passing
+        = (status.exitstatus == 0)\n  end\n\n  step do\n    modified_implementation
+        = Sublayer::Generators::ModifiedImplementationToPassTestsGenerator.new(\n      implementation_file_contents:
+        File.read(@implementation_file_path),\n      test_file_contents: File.read(@test_file_path),\n      test_output:
+        @test_output\n    ).generate\n\n    Sublayer::Actions::WriteFileAction.new(\n      file_contents:
+        modified_implementation,\n      file_path: @implementation_file_path\n    ).call\n  end\nend\n\n    </example_tdd_agent>\n\n    Sublayer
+        Agents take advantage of other Sublayer components to perform their tasks.\n    Sublayer::Actions
+        are used to perform actions in the outside world, things like saving files,
+        making external api calls, retrieving data, etc\n    Sublayer::Generators
+        are used to make calls to LLMs based on information they receive from Sublayer::Actions
+        or other sources and return structured data for other Sublayer::Actions to
+        do use in the outside world\n\n    The Sublayer Agent DSL consists of 4 main
+        parts:\n    1. trigger: What triggers the agent, currently built into the
+        framework is the trigger_on_files_changed, but the trigger method also accepts
+        a Sublayer::Triggers::Base subclass that defines an initialize method and
+        a setup method that takes an agent as an argument\n                The setup
+        method then calls activate(agent) when the trigger condition is met\n    2.
+        goal: What the agent is trying to achieve, this is a block that returns a
+        boolean\n    3. check_status: A method that checks the status of the agent
+        on its way toward the goal. Usually you update the goal condition here or
+        can perform any Sublayer::Actions to examine the state of the outside world\n    4.
+        step: A method that encapsulates the way the agent should work toward the
+        goal. Sublayer::Actions and Sublayer::Generators are used heavily here.\n\n    Your
+        goal is to rely on the above information about how Sublayer Agents work to
+        generate a new Sublayer agent based on the following information:\n\n    Agent
+        description: a sublayer agent that monitors a transcription folder and updates
+        a notion crm with information from the latest transcriptions\n    Trigger
+        condition: \n    Goal condition: all the transcription files in the folder
+        have been processed\n    Status check method: see if there are any files in
+        the transcription folder that havent been procesed\n    Step action method:
+        take an unprocessed transcription file, generate a summary, and any followups,
+        and update the notion crm with the information\n\n    You can assume that
+        any Sublayer::Actions or Sublayer::Generators you need are available to you
+        in the Sublayer framework\n\n    Take a deep breath and think step by step
+        before coding. You can do this!\n"}],"tool_choice":{"type":"function","function":{"name":"sublayer_agent"}},"tools":[{"type":"function","function":{"name":"sublayer_agent","description":"The
+        new sublayer agent based on the description and supporting information","parameters":{"type":"object","properties":{"sublayer_agent":{"type":"object","description":"The
+        new sublayer agent based on the description and supporting information","properties":{"code":{"type":"string","description":"The
+        code of the generated Sublayer agent"},"filename":{"type":"string","description":"The
+        filename of the generated sublayer agent snake cased with a .rb extension"}},"required":["code","filename"]}}},"required":["sublayer_agent"]}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Aug 2024 02:11:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - sublayer
+      Openai-Processing-Ms:
+      - '3966'
+      Openai-Version:
+      - '2020-10-01'
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '10000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '9999069'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 5ms
+      X-Request-Id:
+      - req_edd4c80766304c4cec3bc673dd15c74c
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=vLqCHS8I0bZDMzr7EIJiRFN6MvZSrE6FXZUcf49JZh4-1724897467-1.0.1.1-SnBwRczWHPfXQLZl4inc_DFbuZWzM8r9yFc88R52ey6bbsZzwopD1gSj7tiUUFs3tfp5V2joEfn1xtyYDMbxWw;
+        path=/; expires=Thu, 29-Aug-24 02:41:07 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=MS8cIRI.Fw5AKFj11aNtwGwjO0T9OT7on32uDfcuwsk-1724897467804-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8ba9021af953430e-EWR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-A1Oulw0wXxGTEptK6FT4mZfBe4mIL",
+          "object": "chat.completion",
+          "created": 1724897463,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                  {
+                    "id": "call_jSKNvLx7n7i1Ylicx1mIj05m",
+                    "type": "function",
+                    "function": {
+                      "name": "sublayer_agent",
+                      "arguments": "{\"sublayer_agent\":{\"code\":\"class NotionCRMTranscriptionAgent < Sublayer::Agents::Base\\n  def initialize(transcription_folder_path:, notion_api_client:)\\n    @transcription_folder_path = transcription_folder_path\\n    @notion_api_client = notion_api_client\\n  end\\n\\n  trigger_on_files_changed { Dir.glob(File.join(@transcription_folder_path, '*.txt')) }\\n\\n  goal_condition do\\n    Dir.glob(File.join(@transcription_folder_path, '*.txt')).empty?\\n  end\\n\\n  check_status do\\n    @unprocessed_files = Dir.glob(File.join(@transcription_folder_path, '*.txt'))\\n  end\\n\\n  step do\\n    return if @unprocessed_files.empty?\\n\\n    transcription_file = @unprocessed_files.first\\n    summary = Sublayer::Generators::SummaryGenerator.new(\\n      file_contents: File.read(transcription_file)\\n    ).generate\\n\\n    follow_ups = Sublayer::Generators::FollowUpGenerator.new(\\n      summary: summary\\n    ).generate\\n\\n    Sublayer::Actions::UpdateNotionCRMAction.new(\\n      notion_api_client: @notion_api_client,\\n      summary: summary,\\n      follow_ups: follow_ups\\n    ).call\\n\\n    File.delete(transcription_file)\\n  end\\nend\\n\",\"filename\":\"notion_crm_transcription_agent.rb\"}}"
+                    }
+                  }
+                ],
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 901,
+            "completion_tokens": 292,
+            "total_tokens": 1193
+          },
+          "system_fingerprint": "fp_9722793223"
+        }
+  recorded_at: Thu, 29 Aug 2024 02:11:07 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Interactive agent generator similar to the `sublayer generate generator` command.

You get asked to confirm that you'll be making a call to an AI service and will incur costs to generate the code, then you'll be asked for the provider and model you want to use.

After that, you'll be asked a series of questions about the agent you want to build, describe it, what triggers it, what its goal is, how it checks status, and how it takes a step. After that it generates the agent for you to start working with.

Need to play with it a bit more, but the confirmation step and selecting models should be optional I think or at least have a way to turn it off, can get annoying one you know what you want, but is also nice to be able to try out generation between different models.

Also noticing we probably want to be able to officially support a locally running model in the CLI at some point...