### PR TITLE
Fix zeitwerk loading issue

### DIFF
--- a/lib/sublayer.rb
+++ b/lib/sublayer.rb
@@ -16,6 +16,8 @@ require_relative "sublayer/version"
 loader = Zeitwerk::Loader.for_gem
 loader.inflector.inflect('open_ai' => 'OpenAI')
 loader.inflector.inflect("cli" => "CLI")
+loader.ignore("#{__dir__}/sublayer/cli")
+loader.ignore("#{__dir__}/sublayer/cli.rb")
 loader.setup
 
 module Sublayer
@@ -33,3 +35,5 @@ module Sublayer
     yield(configuration) if block_given?
   end
 end
+
+loader.eager_load


### PR DESCRIPTION
Was wondering why I wasn't seeing any errors on my end. Apparently Zeitwerk has a method called `eager_load_all` that I'm assuming Rails calls to make sure all dependencies classes are loaded. Added a few ignores and eager load to the entry point for the gem.

This causes the tests to fail if files are either not named or ignored correctly