### PR TITLE
remove tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sublayer
 
 A model-agnostic Ruby AI Agent framework. Provides base classes for
-building Generators, Actions, Tasks, and Agents that can be used to build AI
+building Generators, Actions, and Agents that can be used to build AI
 powered applications in Ruby.
 
 For more detailed documentation visit our documentation site: [https://docs.sublayer.com](https://docs.sublayer.com).

--- a/lib/sublayer/tasks/base.rb
+++ b/lib/sublayer/tasks/base.rb
@@ -1,6 +1,0 @@
-module Sublayer
-  module Tasks
-    class Base
-    end
-  end
-end

--- a/sublayer.gemspec
+++ b/sublayer.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
 
   spec.summary = "A model-agnostic Ruby GenerativeAI DSL and Framework"
-  spec.description = "A DSL and framework for building AI powered applications through the use of Generators, Actions, Tasks, and Agents"
+  spec.description = "A DSL and framework for building AI powered applications through the use of Generators, Actions, and Agents"
   spec.homepage = "https://docs.sublayer.com"
   spec.required_ruby_version = ">= 2.6.0"
 


### PR DESCRIPTION
Removing the mention of sublayer tasks


Note: the presence of a base task leads the documentation agent to want to add documentation around what it perceives to be a "new" feature in sublayer