### PR TITLE
Add `ostruct` as dependency to prevent warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport
       httparty
       listen
+      ostruct
       ruby-openai
       thor
       zeitwerk
@@ -59,6 +60,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.3.0)
     mutex_m (0.1.2)
+    ostruct (0.6.1)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -100,6 +102,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -110,4 +113,4 @@ DEPENDENCIES
   webmock (~> 3)
 
 BUNDLED WITH
-   2.4.17
+   2.6.9

--- a/sublayer.gemspec
+++ b/sublayer.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "zeitwerk"
   spec.add_dependency "httparty"
   spec.add_dependency "listen"
+  spec.add_dependency "ostruct"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "rspec", "~> 3.12"


### PR DESCRIPTION
Add `ostruct` to prevent this warning:

```
/Users/andy/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/sublayer-0.2.8/lib/sublayer.rb:7:
warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```