### PR TITLE
Check Gemini response success before trying to parse usage metadata

### DIFF
--- a/lib/sublayer/providers/gemini.rb
+++ b/lib/sublayer/providers/gemini.rb
@@ -40,6 +40,8 @@ module Sublayer
         after_request = Time.now
         response_time = after_request - before_request
 
+        raise "Error generating with Gemini, error: #{response.body}" unless response.success?
+
         Sublayer.configuration.logger.log(:info, "Gemini API response", {
           request_id: request_id,
           response_time: response_time,
@@ -49,8 +51,6 @@ module Sublayer
             total_tokens: response["usageMetadata"]["totalTokenCount"]
           }
         })
-
-        raise "Error generating with Gemini, error: #{response.body}" unless response.success?
 
         output = response.dig("candidates", 0, "content", "parts", 0, "text")
 


### PR DESCRIPTION
If the API key is missing, Gemini will respond with:

```json
{
  "error": {
    "code": 403,
    "message": "Method doesn't allow unregistered callers (callers without established identity). Please use API Key or other form of API consumer identity to call this API.",
    "status": "PERMISSION_DENIED"
  }
}
```

so `response["usageMetadata"]["promptTokenCount"]` will raise an exception about a method being called on `nil`.

(there may be use cases where there is an error but `usageMetadata` is still available. If so, then a check for that key's presence would be better).