### PR TITLE
Bump ruby version in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0']
+        ruby-version: ['3.1']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Use Ruby 3.1 in CI to support latest bundler