### PR TITLE
Make it easier to run the tests locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GEMINI_API_KEY=example
+ANTHROPIC_API_KEY=example
+OPENAI_API_KEY=example

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /TAGS
 
 *.DS_Store
+.env

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
       rexml
     csv (3.3.5)
     diff-lcs (1.5.0)
+    dotenv (3.1.8)
     drb (2.1.1)
       ruby2_keywords
     event_stream_parser (0.3.0)
@@ -109,6 +110,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  dotenv (~> 3.1)
   pry (~> 0.14)
   rspec (~> 3.12)
   sublayer!

--- a/bin/setup
+++ b/bin/setup
@@ -4,5 +4,4 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
-
-# Do any other automated setup that you need to do here
+cp .env.example .env

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+require "dotenv/load"
+
+unless ENV["OPENAI_API_KEY"] && ENV["ANTHROPIC_API_KEY"] && ENV["GEMINI_API_KEY"]
+  puts <<~EOS
+    Some API keys are missing from the environment.
+    You can run `bin/setup` to configure dummy API keys.
+    If you need to add or update any VCR cassettes then you will need to use real keys.
+  EOS
+  exit(1)
+end
+
 require "sublayer"
 require "pry"
 require "vcr"

--- a/sublayer.gemspec
+++ b/sublayer.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ostruct"
   spec.add_dependency "thor"
 
+  spec.add_development_dependency "dotenv", "~> 3.1"
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency "pry", "~> 0.14"
   spec.add_development_dependency "vcr", "~> 6.0"


### PR DESCRIPTION
Cloning and running the test locally results in many errors when the API keys are missing. I think it would be helpful to provide an easy to run the tests using dummy keys.