### PR TITLE
Add Rake as development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (6.0.0)
+    rake (13.3.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -112,6 +113,7 @@ PLATFORMS
 DEPENDENCIES
   dotenv (~> 3.1)
   pry (~> 0.14)
+  rake
   rspec (~> 3.12)
   sublayer!
   vcr (~> 6.0)

--- a/sublayer.gemspec
+++ b/sublayer.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor"
 
   spec.add_development_dependency "dotenv", "~> 3.1"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency "pry", "~> 0.14"
   spec.add_development_dependency "vcr", "~> 6.0"


### PR DESCRIPTION
Allows running the default task (`spec`) with `bundle exec rake`.